### PR TITLE
swap order of blacklist buttons

### DIFF
--- a/frontend/src/views/Blacklist.svelte
+++ b/frontend/src/views/Blacklist.svelte
@@ -61,8 +61,8 @@
                 <span slot="title">Blacklist</span>
                 <div slot="body" class="body-wrapper">
                     <div class="row" style="gap: 10px">
-                        <Button icon="fas fa-ban" on:click={() => blacklistUserModal = true}>Blacklist New User</Button>
                         <Button icon="fas fa-ban" on:click={() => blacklistRoleModal = true}>Blacklist New Role</Button>
+                        <Button icon="fas fa-ban" on:click={() => blacklistUserModal = true}>Blacklist New User</Button>
                     </div>
 
                     <hr/>


### PR DESCRIPTION
Swapping the two blacklist buttons on web dashboard.  Roles should be first to be more consistent with how the section below renders.

<img width="1426" alt="Screenshot 2025-02-02 at 6 59 13 PM" src="https://github.com/user-attachments/assets/084388c6-b07e-4f37-940c-d0a0f57842eb" />
