### PR TITLE
updated tooltipLink to proper place to help users

### DIFF
--- a/frontend/src/components/manage/PanelCreationForm.svelte
+++ b/frontend/src/components/manage/PanelCreationForm.svelte
@@ -58,7 +58,7 @@
                            bind:value={data.naming_scheme}
                            placeholder="ticket-%id%"
                            tooltipText="Click here for the full placeholder list"
-                           tooltipLink="https://docs.ticketsbot.cloud" />
+                           tooltipLink="https://docs.ticketsbot.cloud/dashboard/settings/placeholders#custom-naming-scheme-placeholders" />
                 {/if}
             </div>
             <div class="incomplete-row">


### PR DESCRIPTION
This tooltip was just pointing to the first page of docs.
Changed it to point to the specific section of docs dealing with naming scheme placeholders.

<img width="1157" alt="Screenshot 2025-02-03 at 6 28 58 PM" src="https://github.com/user-attachments/assets/fe52c2c7-65d5-41fd-bd19-639382628911" />


Link updated to: https://docs.ticketsbot.cloud/dashboard/settings/placeholders#custom-naming-scheme-placeholders