### PR TITLE
Cache updated guild icon and/or name

### DIFF
--- a/frontend/src/includes/ManageSidebar.svelte
+++ b/frontend/src/includes/ManageSidebar.svelte
@@ -124,11 +124,39 @@
         guild = res.data;
     }
 
+    function checkGuildCache(id, newIcon, newName) {
+        // Retrieve the guilds array from localStorage
+        let guilds = JSON.parse(window.localStorage.getItem('guilds')) || [];
+
+        // Find the guild with the specified id
+        let guild = guilds.find(g => g.id === id);
+
+        // If the guild is found, update its icon and name
+        if (guild) {
+            let updated = false;
+            if (guild.icon !== newIcon) {
+                guild.icon = newIcon;
+                updated = true;
+            }
+            if (guild.name !== newName) {
+                guild.name = newName;
+                updated = true;
+            }
+            // Save the updated guilds array back to localStorage if there were changes
+            if (updated) {
+                window.localStorage.setItem('guilds', JSON.stringify(guilds));
+            }
+        } else {
+            console.error(`Guild with id ${id} not found`);
+        }
+    }
+
     onMount(async () => {
         await withLoadingScreen(async () => {
             await loadGuild();
 
             iconUrl = getIconUrl(guildId, guild.icon);
+            checkGuildCache(guildId, guild.icon, guild.name);
         })
     });
 </script>


### PR DESCRIPTION
When a user updates their server icon and/or name, it does not update in the guild cache, which leads to the server listing always showing the old icon and/or name until they refresh the list. This fixes that by checking if the guild icon or name has been changed and updates the cache.

(This is all untested so please test it for me before merging)
**How to check if the code works:**

1. Open the dashboard.
2. Inspect elements.
3. Go into application.
4. Open local storage.
5. Find the guilds key and change one of the server's icon or name. Reload.
6. Click/open the server settings.
7. Go back.
8. Reload.
9. The icon and/or name should be fixed then (hopefully).