### PR TITLE
feat(RM96): add validation to image url inputs

### DIFF
--- a/app/http/endpoints/api/panel/validation.go
+++ b/app/http/endpoints/api/panel/validation.go
@@ -167,12 +167,12 @@ func validateEmoji(c PanelValidationContext) validation.ValidationFunc {
 	}
 }
 
-var urlRegex = regexp.MustCompile(`^https?://([-a-zA-Z0-9@:%._+~#=]{1,256})\.[a-zA-Z0-9()]{1,63}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)$`)
+var urlRegex = regexp.MustCompile(`^https?://([-a-zA-Z0-9@:%._+~#=]{1,256})\.[a-zA-Z0-9()]{1,63}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*\.(?:gif|jpg|jpeg|png|webp))$`)
 
 func validateNullableUrl(url *string) validation.ValidationFunc {
 	return func() error {
 		if url != nil && (len(*url) > 255 || !urlRegex.MatchString(*url)) {
-			return validation.NewInvalidInputError("Invalid URL")
+			return validation.NewInvalidInputError("Invalid image URL. Must end with .gif, .jpg, .jpeg, .png, or .webp")
 		}
 
 		return nil
@@ -361,13 +361,13 @@ func validateEmbed(e *types.CustomEmbed) error {
 	if e == nil || e.Title != nil || e.Description != nil || len(e.Fields) > 0 || e.ImageUrl != nil || e.ThumbnailUrl != nil {
 		if e.ImageUrl != nil && (len(*e.ImageUrl) > 255 || !urlRegex.MatchString(*e.ImageUrl)) {
 			if *e.ImageUrl != "%avatar_url%" {
-				return validation.NewInvalidInputError("Invalid URL")
+				return validation.NewInvalidInputError("Invalid image URL. Must end with .gif, .jpg, .jpeg, .png, or .webp")
 			}
 		}
 
 		if e.ThumbnailUrl != nil && (len(*e.ThumbnailUrl) > 255 || !urlRegex.MatchString(*e.ThumbnailUrl)) {
 			if *e.ThumbnailUrl != "%avatar_url%" {
-				return validation.NewInvalidInputError("Invalid URL")
+				return validation.NewInvalidInputError("Invalid image URL. Must end with .gif, .jpg, .jpeg, .png, or .webp")
 			}
 		}
 

--- a/frontend/src/components/manage/PanelCreationForm.svelte
+++ b/frontend/src/components/manage/PanelCreationForm.svelte
@@ -147,8 +147,8 @@
             </div>
 
             <div class="row">
-                <Input col2={true} label="Large Image URL" badge="Optional" bind:value={data.image_url} placeholder="https://example.com/image.png" />
-                <Input col2={true} label="Small Image URL" badge="Optional" bind:value={data.thumbnail_url} placeholder="https://example.com/image.png" />
+                <Input col2={true} label="Large Image URL" badge="Optional" bind:value={data.image_url} placeholder="https://example.com/image.png" on:blur={handleImageUrlInput}/>
+                <Input col2={true} label="Small Image URL" badge="Optional" bind:value={data.thumbnail_url} placeholder="https://example.com/image.png"  on:blur={handleImageUrlInput}/>
             </div>
         </div>
     </Collapsible>
@@ -267,6 +267,21 @@
             id: emoji.id,
             name: emoji.name
         };
+    }
+
+    // Function to validate image URL
+    function validateImageUrl(url) {
+        const validExtensions = ['.gif', '.jpg', '.jpeg', '.png', '.webp'];
+        return validExtensions.some(ext => url.endsWith(ext));
+    }
+
+    // Function to handle input validation
+    function handleImageUrlInput(event) {
+        const url = event.target.value;
+        if (url && !validateImageUrl(url)) {
+            alert('Invalid image URL. Please use a URL ending with .gif, .jpg, .jpeg, .png, or .webp');
+            event.target.value = '';
+        }
     }
 
     function updateColour() {

--- a/frontend/src/components/manage/PanelCreationForm.svelte
+++ b/frontend/src/components/manage/PanelCreationForm.svelte
@@ -147,8 +147,8 @@
             </div>
 
             <div class="row">
-                <Input col2={true} label="Large Image URL" badge="Optional" bind:value={data.image_url} placeholder="https://example.com/image.png" on:blur={handleImageUrlInput}/>
-                <Input col2={true} label="Small Image URL" badge="Optional" bind:value={data.thumbnail_url} placeholder="https://example.com/image.png"  on:blur={handleImageUrlInput}/>
+                <Input col2={true} label="Large Image URL" badge="Optional" bind:value={data.image_url} placeholder="https://example.com/image.png" />
+                <Input col2={true} label="Small Image URL" badge="Optional" bind:value={data.thumbnail_url} placeholder="https://example.com/image.png" />
             </div>
         </div>
     </Collapsible>
@@ -267,21 +267,6 @@
             id: emoji.id,
             name: emoji.name
         };
-    }
-
-    // Function to validate image URL
-    function validateImageUrl(url) {
-        const validExtensions = ['.gif', '.jpg', '.jpeg', '.png', '.webp'];
-        return validExtensions.some(ext => url.endsWith(ext));
-    }
-
-    // Function to handle input validation
-    function handleImageUrlInput(event) {
-        const url = event.target.value;
-        if (url && !validateImageUrl(url)) {
-            alert('Invalid image URL. Please use a URL ending with .gif, .jpg, .jpeg, .png, or .webp');
-            event.target.value = '';
-        }
     }
 
     function updateColour() {


### PR DESCRIPTION
currently there is no validation on the Small Image URL or Large Image URL inputs in a ticket panel settings.

This is an attempt to require the user to have one of the Discord acceptable image filetypes (.gif, .jpg, .jpeg, .png, or .webp)