### PR TITLE
Textarea resize

### DIFF
--- a/frontend/public/global.css
+++ b/frontend/public/global.css
@@ -37,6 +37,10 @@ label {
 	display: block;
 }
 
+textarea {
+	resize: vertical;
+}
+
 input, button, select, textarea {
 	font-family: inherit;
 	font-size: inherit;

--- a/frontend/public/global.css
+++ b/frontend/public/global.css
@@ -39,6 +39,7 @@ label {
 
 textarea {
 	resize: vertical;
+	max-height: 500px;
 }
 
 input, button, select, textarea {

--- a/frontend/src/components/Collapsible.svelte
+++ b/frontend/src/components/Collapsible.svelte
@@ -79,7 +79,7 @@
     }
 
     function updateSize() {
-        content.style.maxHeight = `${content.scrollHeight}px`;
+        content.style.maxHeight = `100%`;
     }
 
     function updateIfExpanded() {


### PR DESCRIPTION
Rn can you both horizontal and vertical resize textareas which can cause the textarea to completely break the styling, like go out of the container etc

This allows you to resize it vertically and not have it break the styling

Before:
![image](https://github.com/user-attachments/assets/f8ec8674-3a0c-4ef1-9a9d-a651cdf0f8d7)
![image](https://github.com/user-attachments/assets/aad5276d-6185-4938-bebf-7a32dbf60542)

After:
![image](https://github.com/user-attachments/assets/7379a6ee-9674-4084-b97e-0ea5dcdc436f)

Btw this is tested using inspect element, so it _should_ work, tho still a good idea to check it out



