### PR TITLE
Add secure connection option for S3

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -84,7 +84,7 @@ func main() {
 	cache.Instance = cache.NewCache()
 
 	logger.Info("Connecting to import S3")
-	s3.ConnectS3(config.Conf.S3Import.Endpoint, config.Conf.S3Import.AccessKey, config.Conf.S3Import.SecretKey)
+	s3.ConnectS3(config.Conf.S3Import.Endpoint, config.Conf.S3Import.AccessKey, config.Conf.S3Import.SecretKey, config.Conf.S3Import.Secure)
 
 	logger.Info("Initialising microservice clients")
 	utils.ArchiverClient = archiverclient.NewArchiverClient(archiverclient.NewProxyRetriever(config.Conf.Bot.ObjectStore), []byte(config.Conf.Bot.AesKey))

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	SecureProxyUrl string `env:"SECURE_PROXY_URL"`
 	S3Import       struct {
 		Endpoint         string `env:"ENDPOINT,required"`
+		Secure           bool   `env:"SECURE" envDefault:"true"`
 		AccessKey        string `env:"ACCESS_KEY,required"`
 		SecretKey        string `env:"SECRET_KEY,required"`
 		TranscriptBucket string `env:"TRANSCRIPT_BUCKET,required"`

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -9,11 +9,11 @@ import (
 
 var S3Client *minio.Client
 
-func ConnectS3(endpoint, accessKey, secretKey string) {
+func ConnectS3(endpoint, accessKey, secretKey string, secure bool) {
 	// Initialize minio client object.
 	minioClient, err := minio.New(endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(accessKey, secretKey, ""),
-		Secure: true,
+		Secure: secure,
 	})
 	if err != nil {
 		log.Fatalln(err)


### PR DESCRIPTION
This PR adds a feature for users who do not want to deal with TLS with S3. *This is mostly a feature for self-hosted instances of the bot.*

This pull request introduces changes to add a `Secure` configuration option for S3 connections. The most important changes include modifying the S3 connection function to accept a `secure` parameter, updating the configuration struct to include this new parameter, and adjusting the main function to pass the `secure` parameter when connecting to S3.

Changes to S3 connection:

* [`s3/s3.go`](diffhunk://#diff-be17c68f9ea4ef7116c459bb5231d37fe1421c80cf546dbc8e2f524624fb8068L12-R16): Modified the `ConnectS3` function to accept a `secure` parameter and use it in the Minio client initialization.

Configuration updates:

* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R62): Added a `Secure` field to the `S3Import` struct in the configuration, with a default value of `true`.

Main function adjustments:

* [`cmd/api/main.go`](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL87-R87): Updated the S3 connection call in the `main` function to include the new `secure` parameter from the configuration.

## More Pull Requests
- https://github.com/TicketsBot-cloud/logarchiver/pull/1
- https://github.com/TicketsBot-cloud/import-sync/pull/2