### PR TITLE
fix(RM-71, RM-72, RM-74): Loading State Management

### DIFF
--- a/frontend/src/components/manage/SettingsCard.svelte
+++ b/frontend/src/components/manage/SettingsCard.svelte
@@ -1,4 +1,4 @@
-{#if data}
+{#if data && loaded}
   <Card footer="{false}" fill="{false}">
   <span slot="title">
     Settings
@@ -217,6 +217,7 @@
     let channels = [];
     let panels = [];
     let isPremium = false;
+    let loaded = false;
 
     let data;
 
@@ -408,6 +409,7 @@
             loadPremium(),
             loadSettings()
         ]);
+        loaded = true;
 
         if (data.archive_channel && !channels.some(c => c.id === data.archive_channel)) {
             await loadChannels(true);


### PR DESCRIPTION
This pull request includes changes to the `frontend/src/components/manage/SettingsCard.svelte` file to ensure that the settings card is only displayed when the data is fully loaded. The most important changes include adding a new `loaded` variable and updating the conditional rendering logic.

Changes to conditional rendering and state management:

* Added a new `loaded` variable to track the loading state.
* Updated the conditional rendering logic to check both `data` and `loaded` before displaying the settings card.
* Set the `loaded` variable to `true` after loading premium settings and other settings data.