### PR TITLE
feat: Use configurable PoweredBy and IconUrl

### DIFF
--- a/app/http/endpoints/api/panel/multipanelmessagedata.go
+++ b/app/http/endpoints/api/panel/multipanelmessagedata.go
@@ -40,7 +40,6 @@ func multiPanelIntoMessageData(panel database.MultiPanel, isPremium bool) multiP
 
 func (d *multiPanelMessageData) send(ctx *botcontext.BotContext, panels []database.Panel) (uint64, error) {
 	if !d.IsPremium {
-		// TODO: Don't harcode
 		d.Embed.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 

--- a/app/http/endpoints/api/panel/multipanelmessagedata.go
+++ b/app/http/endpoints/api/panel/multipanelmessagedata.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"math"
+	"fmt"
 
 	"github.com/TicketsBot-cloud/dashboard/botcontext"
 	"github.com/TicketsBot-cloud/dashboard/utils/types"
@@ -40,7 +41,7 @@ func multiPanelIntoMessageData(panel database.MultiPanel, isPremium bool) multiP
 func (d *multiPanelMessageData) send(ctx *botcontext.BotContext, panels []database.Panel) (uint64, error) {
 	if !d.IsPremium {
 		// TODO: Don't harcode
-		d.Embed.SetFooter(`Powered by ${config.Conf.Bot.PoweredBy}`, config.Conf.Bot.IconUrl)
+		d.Embed.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 
 	var components []component.Component

--- a/app/http/endpoints/api/panel/multipanelmessagedata.go
+++ b/app/http/endpoints/api/panel/multipanelmessagedata.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/TicketsBot-cloud/dashboard/botcontext"
 	"github.com/TicketsBot-cloud/dashboard/utils/types"
+	"github.com/TicketsBot-cloud/dashboard/config"
 	"github.com/TicketsBot-cloud/database"
 	"github.com/rxdn/gdl/objects/channel/embed"
 	"github.com/rxdn/gdl/objects/interaction/component"
@@ -39,7 +40,7 @@ func multiPanelIntoMessageData(panel database.MultiPanel, isPremium bool) multiP
 func (d *multiPanelMessageData) send(ctx *botcontext.BotContext, panels []database.Panel) (uint64, error) {
 	if !d.IsPremium {
 		// TODO: Don't harcode
-		d.Embed.SetFooter("Powered by ticketsbot.cloud", "https://ticketsbot.cloud/assets/img/logo.png")
+		d.Embed.SetFooter(`Powered by ${config.Conf.Bot.PoweredBy}`, config.Conf.Bot.IconUrl)
 	}
 
 	var components []component.Component

--- a/app/http/endpoints/api/panel/panelmessagedata.go
+++ b/app/http/endpoints/api/panel/panelmessagedata.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/TicketsBot-cloud/dashboard/app"
 	"github.com/TicketsBot-cloud/dashboard/botcontext"
+	"github.com/TicketsBot-cloud/dashboard/config"
 	"github.com/TicketsBot-cloud/database"
 	"github.com/rxdn/gdl/objects"
 	"github.com/rxdn/gdl/objects/channel/embed"
@@ -70,7 +71,7 @@ func (p *panelMessageData) send(c *botcontext.BotContext) (uint64, error) {
 	}
 
 	if !p.IsPremium {
-		e.SetFooter("Powered by ticketsbot.cloud", "https://ticketsbot.cloud/assets/img/logo.png")
+		e.SetFooter(`Powered by ${config.Conf.Bot.PoweredBy}`, config.Conf.Bot.IconUrl)
 	}
 
 	data := rest.CreateMessageData{

--- a/app/http/endpoints/api/panel/panelmessagedata.go
+++ b/app/http/endpoints/api/panel/panelmessagedata.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"fmt"
+
 	"github.com/TicketsBot-cloud/dashboard/app"
 	"github.com/TicketsBot-cloud/dashboard/botcontext"
 	"github.com/TicketsBot-cloud/dashboard/config"
@@ -71,7 +73,7 @@ func (p *panelMessageData) send(c *botcontext.BotContext) (uint64, error) {
 	}
 
 	if !p.IsPremium {
-		e.SetFooter(`Powered by ${config.Conf.Bot.PoweredBy}`, config.Conf.Bot.IconUrl)
+		e.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 
 	data := rest.CreateMessageData{

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,8 @@ type Config struct {
 		ImageProxySecret                     string `env:"IMAGE_PROXY_SECRET" toml:"image-proxy-secret"`
 		PublicIntegrationRequestWebhookId    uint64 `env:"PUBLIC_INTEGRATION_REQUEST_WEBHOOK_ID" toml:"public-integration-request-webhook-id"`
 		PublicIntegrationRequestWebhookToken string `env:"PUBLIC_INTEGRATION_REQUEST_WEBHOOK_TOKEN" toml:"public-integration-request-webhook-token"`
+		PoweredBy                            string `env:"POWEREDBY" envDefault:"ticketsbot.cloud"`
+		IconUrl                              string `env:"ICON_URL" envDefault:"https://ticketsbot.cloud/assets/img/logo.png"`
 	}
 	Redis struct {
 		Host     string `env:"HOST,required"`


### PR DESCRIPTION
This pull request includes changes to integrate configuration values for the footer text and icon URL, which were previously hardcoded. The changes primarily involve updating the `config` package and modifying the footer settings in the `multiPanelMessageData` and `panelMessageData` structures.

Integration of configuration values:

* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R49-R50): Added `PoweredBy` and `IconUrl` fields to the `Config` struct to allow configuration of the footer text and icon URL.

Updates to footer settings:

* [`app/http/endpoints/api/panel/multipanelmessagedata.go`](diffhunk://#diff-4361880df70b0af49eb502fe94f0c65d4e72cb66bb822c2aac0a9b4ad7d7d20bL42-R43): Modified the `send` method in `multiPanelMessageData` to use `config.Conf.Bot.PoweredBy` and `config.Conf.Bot.IconUrl` for setting the footer text and icon URL.
* [`app/http/endpoints/api/panel/panelmessagedata.go`](diffhunk://#diff-9e722bd087af3efabdb26133fbf06d925f755a8547637761d7c887eb6973724eL73-R74): Modified the `send` method in `panelMessageData` to use `config.Conf.Bot.PoweredBy` and `config.Conf.Bot.IconUrl` for setting the footer text and icon URL.

Import adjustments:

* [`app/http/endpoints/api/panel/multipanelmessagedata.go`](diffhunk://#diff-4361880df70b0af49eb502fe94f0c65d4e72cb66bb822c2aac0a9b4ad7d7d20bR9): Added import for the `config` package.
* [`app/http/endpoints/api/panel/panelmessagedata.go`](diffhunk://#diff-9e722bd087af3efabdb26133fbf06d925f755a8547637761d7c887eb6973724eR6): Added import for the `config` package.