### PR TITLE
fix: Mobile burger menu not being scrollable

### DIFF
--- a/frontend/src/includes/Navbar.svelte
+++ b/frontend/src/includes/Navbar.svelte
@@ -121,7 +121,7 @@
 
         .navbar.dropdown, .wrapper.dropdown {
             height: 100%;
-            overflow: hidden;
+            overflow: scroll;
         }
 
         .wrapper.dropdown {


### PR DESCRIPTION
This pull request includes a small change to the `frontend/src/includes/Navbar.svelte` file. The change modifies the CSS property for the `.navbar.dropdown` and `.wrapper.dropdown` classes to allow scrolling instead of hiding overflow content.

* [`frontend/src/includes/Navbar.svelte`](diffhunk://#diff-8a39f7acb5c3550e89fd8080748d0687a0a2606f42a5c7a939703168219bfcbcL124-R124): Changed `overflow` property from `hidden` to `scroll` for `.navbar.dropdown` and `.wrapper.dropdown` classes.