### PR TITLE
feat(RM-116): Added InteractionsBaseUrl to config

### DIFF
--- a/app/http/endpoints/api/whitelabel/whitelabelpost.go
+++ b/app/http/endpoints/api/whitelabel/whitelabelpost.go
@@ -12,6 +12,7 @@ import (
 	"github.com/TicketsBot-cloud/common/tokenchange"
 	"github.com/TicketsBot-cloud/common/whitelabeldelete"
 	"github.com/TicketsBot-cloud/dashboard/app"
+	"github.com/TicketsBot-cloud/dashboard/config"
 	dbclient "github.com/TicketsBot-cloud/dashboard/database"
 	"github.com/TicketsBot-cloud/dashboard/redis"
 	"github.com/TicketsBot-cloud/dashboard/utils"
@@ -91,8 +92,7 @@ func WhitelabelPost() func(*gin.Context) {
 				application.FlagIntentGatewayGuildMembersLimited,
 				application.FlagGatewayMessageContentLimited,
 			)),
-			// TODO: Don't hardcode URL
-			InteractionsEndpointUrl: utils.Ptr(fmt.Sprintf("https://gateway.ticketsbot.cloud/handle/%d", bot.Id)),
+			InteractionsEndpointUrl: utils.Ptr(fmt.Sprintf("%s/handle/%d", config.Conf.Bot.InteractionsBaseUrl, bot.Id)),
 		}
 
 		if _, err := rest.EditCurrentApplication(context.Background(), data.Token, nil, editData); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 		ObjectStore                          string `env:"LOG_ARCHIVER_URL"`
 		AesKey                               string `env:"LOG_AES_KEY" toml:"aes-key"`
 		ProxyUrl                             string `env:"DISCORD_PROXY_URL" toml:"discord-proxy-url"`
+		InteractionsBaseUrl                  string `env:"INTERACTIONS_BASE_URL" envDefault:"https://gateway.ticketsbot.cloud"`
 		RenderServiceUrl                     string `env:"RENDER_SERVICE_URL" toml:"render-service-url"`
 		ImageProxySecret                     string `env:"IMAGE_PROXY_SECRET" toml:"image-proxy-secret"`
 		PublicIntegrationRequestWebhookId    uint64 `env:"PUBLIC_INTEGRATION_REQUEST_WEBHOOK_ID" toml:"public-integration-request-webhook-id"`


### PR DESCRIPTION
*This is mostly a feature for self-hosted instances of the bot.*

This pull request introduces a configuration-driven approach to handling the `InteractionsEndpointUrl` in the `WhitelabelPost` endpoint, replacing the previously hardcoded URL. It also updates the configuration structure to support this change. Below are the key changes:

### Configuration Updates:
* Added a new configuration field, `InteractionsBaseUrl`, to the `Config` struct in `config/config.go`. This field is populated from the `INTERACTIONS_BASE_URL` environment variable, with a default value of `https://gateway.ticketsbot.cloud`.

### Endpoint Updates:
* Modified the `WhitelabelPost` function in `whitelabelpost.go` to use the new `InteractionsBaseUrl` configuration field instead of a hardcoded URL for the `InteractionsEndpointUrl`.