### PR TITLE
fix(RM-76): Allow blank status & add Custom & Competing status

### DIFF
--- a/app/http/endpoints/api/whitelabel/whitelabelstatusdelete.go
+++ b/app/http/endpoints/api/whitelabel/whitelabelstatusdelete.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/TicketsBot-cloud/common/statusupdates"
+	"github.com/TicketsBot-cloud/dashboard/app"
+	"github.com/TicketsBot-cloud/dashboard/database"
+	"github.com/TicketsBot-cloud/dashboard/redis"
+	"github.com/TicketsBot-cloud/dashboard/utils"
+	"github.com/gin-gonic/gin"
+)
+
+func WhitelabelStatusDelete(c *gin.Context) {
+	userId := c.Keys["userid"].(uint64)
+
+	// Get bot
+	bot, err := database.Client.Whitelabel.GetByUserId(c, userId)
+	if err != nil {
+		_ = c.AbortWithError(http.StatusInternalServerError, app.NewServerError(err))
+		return
+	}
+
+	// Ensure bot exists
+	if bot.BotId == 0 {
+		c.JSON(404, utils.ErrorStr("No bot found"))
+		return
+	}
+
+	// Update in database
+	if err := database.Client.WhitelabelStatuses.Delete(c, bot.BotId); err != nil {
+		_ = c.AbortWithError(http.StatusInternalServerError, app.NewServerError(err))
+		return
+	}
+
+	// Send status update to sharder
+	go statusupdates.Publish(redis.Client.Client, bot.BotId)
+
+	c.JSON(200, utils.SuccessResponse)
+}

--- a/app/http/endpoints/api/whitelabel/whitelabelstatuspost.go
+++ b/app/http/endpoints/api/whitelabel/whitelabelstatuspost.go
@@ -51,6 +51,8 @@ func WhitelabelStatusPost(c *gin.Context) {
 		user.ActivityTypePlaying,
 		user.ActivityTypeListening,
 		user.ActivityTypeWatching,
+		user.ActivityTypeCompeting,
+		user.ActivityTypeCustom,
 	}
 
 	if !utils.Contains(validActivities, data.StatusType) {

--- a/app/http/server.go
+++ b/app/http/server.go
@@ -215,6 +215,7 @@ func StartServer(logger *zap.Logger, sm *livechat.SocketManager) {
 
 			whitelabelGroup.POST("/", rl(middleware.RateLimitTypeUser, 5, time.Minute), api_whitelabel.WhitelabelPost())
 			whitelabelGroup.POST("/status", rl(middleware.RateLimitTypeUser, 1, time.Second*5), api_whitelabel.WhitelabelStatusPost)
+			whitelabelGroup.DELETE("/status", rl(middleware.RateLimitTypeUser, 1, time.Second*5), api_whitelabel.WhitelabelStatusDelete)
 		}
 	}
 

--- a/frontend/rollup.config.js
+++ b/frontend/rollup.config.js
@@ -71,12 +71,12 @@ export default {
 
         replace({
             env: JSON.stringify({
-				CLIENT_ID: process.env.CLIENT_ID,
-				REDIRECT_URI: process.env.REDIRECT_URI,
-				API_URL: process.env.API_URL,
-				WS_URL: process.env.WS_URL,
-				INVITE_URL: process.env.INVITE_URL,
-			})
+                CLIENT_ID: process.env.CLIENT_ID,
+                REDIRECT_URI: process.env.REDIRECT_URI,
+                API_URL: process.env.API_URL,
+                WS_URL: process.env.WS_URL,
+                INVITE_URL: process.env.INVITE_URL,
+            })
         }),
 
         // In dev mode, call `npm run start` once

--- a/frontend/src/views/Whitelabel.svelte
+++ b/frontend/src/views/Whitelabel.svelte
@@ -31,6 +31,8 @@
                                 <option value="0">Playing</option>
                                 <option value="2">Listening</option>
                                 <option value="3">Watching</option>
+                                <option value="5">Competing</option>
+                                <option value="4">Custom</option>
                             </Dropdown>
 
                             <div class="col-2-3">

--- a/frontend/src/views/Whitelabel.svelte
+++ b/frontend/src/views/Whitelabel.svelte
@@ -44,6 +44,11 @@
                             <Button icon="fas fa-paper-plane" on:click={updateStatus} fullWidth="{true}">
                                 Submit
                             </Button>
+                            {#if bot.status_type != "0" && bot.status != ""}
+                              <Button icon="fas fa-trash-can" on:click={deleteStatus} danger fullWidth="{true}">
+                                Clear Status
+                              </Button>
+                            {/if}
                         </div>
                     </form>
                 </div>
@@ -251,6 +256,21 @@
         }
 
         notifySuccess('Updated status successfully')
+    }
+
+    async function deleteStatus() {
+        const res = await axios.delete(`${API_URL}/user/whitelabel/status`);
+        if (res.status !== 200 || !res.data.success) {
+            if (res.status === 429) {
+                notifyRatelimit()
+            } else {
+                notifyError(res.data.error)
+            }
+
+            return;
+        }
+
+        notifySuccess('Deleted status successfully')
     }
 
     async function loadBot() {


### PR DESCRIPTION
**This PR relies on a PR to https://github.com/TicketsBot-cloud/tickets.rs/pull/1 for the custom status `state` property to be set per the [discord docs](https://discord.com/developers/docs/events/gateway-events#activity-object).**

This pull request introduces a new feature to allow users to delete their whitelabel bot status, expands the available status types, and updates the frontend to support these changes. The most important changes include adding a new API endpoint for deleting statuses, integrating this endpoint into the frontend, and adding new status types to the existing functionality.

### Backend Changes:
* **New API Endpoint for Deleting Whitelabel Bot Status**: Added the `WhitelabelStatusDelete` function in `app/http/endpoints/api/whitelabel/whitelabelstatusdelete.go` to handle DELETE requests for removing a bot's status. This includes database updates and publishing status changes to the sharder.
* **Route Registration**: Registered the new DELETE `/status` route in `StartServer` to connect the endpoint to the server.

### Status Type Enhancements:
* **Additional Status Types**: Added "Competing" and "Custom" as valid status types in `WhitelabelStatusPost` to expand the range of activities users can set.

### Frontend Changes:
* **Dropdown Options Update**: Updated the `Whitelabel.svelte` dropdown to include "Competing" and "Custom" status options.
* **Delete Status Button**: Added a "Clear Status" button in `Whitelabel.svelte` that appears conditionally when a status is set.
* **Delete Status Functionality**: Implemented the `deleteStatus` function in `Whitelabel.svelte` to send DELETE requests to the new API endpoint and handle success or error notifications.