### PR TITLE
feat(rm-40):

### DIFF
--- a/app/http/endpoints/api/panel/panelcreate.go
+++ b/app/http/endpoints/api/panel/panelcreate.go
@@ -26,8 +26,8 @@ import (
 const freePanelLimit = 3
 
 type panelBody struct {
-	ChannelId         uint64                            `json:"channel_id,string"`
-	MessageId         uint64                            `json:"message_id,string"`
+	ChannelId         *uint64                           `json:"channel_id,string"`
+	MessageId         *uint64                           `json:"message_id,string"`
 	Title             string                            `json:"title"`
 	Content           string                            `json:"content"`
 	Colour            uint32                            `json:"colour"`
@@ -50,9 +50,13 @@ type panelBody struct {
 	DeleteMentions    bool                              `json:"delete_mentions"`
 }
 
-func (p *panelBody) IntoPanelMessageData(customId string, isPremium bool) panelMessageData {
-	return panelMessageData{
-		ChannelId:      p.ChannelId,
+func (p *panelBody) IntoPanelMessageData(customId string, isPremium bool) *panelMessageData {
+	if p.ChannelId == nil {
+		// This should never happen. But lets not make assumptions
+		return nil
+	}
+	return &panelMessageData{
+		ChannelId:      *p.ChannelId,
 		Title:          p.Title,
 		Content:        p.Content,
 		CustomId:       customId,
@@ -85,7 +89,7 @@ func CreatePanel(c *gin.Context) {
 		return
 	}
 
-	data.MessageId = 0
+	data.MessageId = nil
 
 	// Check panel quota
 	premiumTier, err := rpc.PremiumClient.GetTierByGuildId(c, guildId, false, botContext.Token, botContext.RateLimiter)
@@ -166,20 +170,23 @@ func CreatePanel(c *gin.Context) {
 	}
 
 	messageData := data.IntoPanelMessageData(customId, premiumTier > premium.None)
-	msgId, err := messageData.send(botContext)
-	if err != nil {
-		var unwrapped request.RestError
-		if errors.As(err, &unwrapped) {
-			if unwrapped.StatusCode == http.StatusForbidden {
-				c.JSON(400, utils.ErrorStr("I do not have permission to send messages in the specified channel"))
+	var msgId *uint64 = nil
+	if messageData != nil {
+		*msgId, err = messageData.send(botContext)
+		if err != nil {
+			var unwrapped request.RestError
+			if errors.As(err, &unwrapped) {
+				if unwrapped.StatusCode == http.StatusForbidden {
+					c.JSON(400, utils.ErrorStr("I do not have permission to send messages in the specified channel"))
+				} else {
+					c.JSON(400, utils.ErrorStr("Error sending panel message: "+unwrapped.ApiError.Message))
+				}
 			} else {
-				c.JSON(400, utils.ErrorStr("Error sending panel message: "+unwrapped.ApiError.Message))
+				_ = c.AbortWithError(http.StatusInternalServerError, app.NewServerError(err))
 			}
-		} else {
-			_ = c.AbortWithError(http.StatusInternalServerError, app.NewServerError(err))
-		}
 
-		return
+			return
+		}
 	}
 
 	var emojiId *uint64

--- a/app/http/endpoints/api/panel/panelcreate.go
+++ b/app/http/endpoints/api/panel/panelcreate.go
@@ -170,9 +170,9 @@ func CreatePanel(c *gin.Context) {
 	}
 
 	messageData := data.IntoPanelMessageData(customId, premiumTier > premium.None)
-	var msgId *uint64 = nil
+	var newMsgId *uint64
 	if messageData != nil {
-		*msgId, err = messageData.send(botContext)
+		msgId, err := messageData.send(botContext)
 		if err != nil {
 			var unwrapped request.RestError
 			if errors.As(err, &unwrapped) {
@@ -187,6 +187,7 @@ func CreatePanel(c *gin.Context) {
 
 			return
 		}
+		newMsgId = &msgId
 	}
 
 	var emojiId *uint64
@@ -219,7 +220,7 @@ func CreatePanel(c *gin.Context) {
 
 	// Store in DB
 	panel := database.Panel{
-		MessageId:           msgId,
+		MessageId:           newMsgId,
 		ChannelId:           data.ChannelId,
 		GuildId:             guildId,
 		Title:               data.Title,

--- a/app/http/endpoints/api/panel/paneldelete.go
+++ b/app/http/endpoints/api/panel/paneldelete.go
@@ -69,11 +69,13 @@ func DeletePanel(c *gin.Context) {
 	}
 
 	// TODO: Set timeout on context
-	if err := rest.DeleteMessage(c, botContext.Token, botContext.RateLimiter, panel.ChannelId, panel.MessageId); err != nil {
-		var unwrapped request.RestError
-		if !errors.As(err, &unwrapped) || unwrapped.StatusCode != 404 {
-			_ = c.AbortWithError(http.StatusInternalServerError, app.NewServerError(err))
-			return
+	if panel.ChannelId != nil && panel.MessageId != nil {
+		if err := rest.DeleteMessage(c, botContext.Token, botContext.RateLimiter, *panel.ChannelId, *panel.MessageId); err != nil {
+			var unwrapped request.RestError
+			if !errors.As(err, &unwrapped) || unwrapped.StatusCode != 404 {
+				_ = c.AbortWithError(http.StatusInternalServerError, app.NewServerError(err))
+				return
+			}
 		}
 	}
 

--- a/app/http/endpoints/api/panel/panelmessagedata.go
+++ b/app/http/endpoints/api/panel/panelmessagedata.go
@@ -27,7 +27,11 @@ type panelMessageData struct {
 	IsPremium                bool
 }
 
-func panelIntoMessageData(panel database.Panel, isPremium bool) panelMessageData {
+func panelIntoMessageData(panel database.Panel, isPremium bool) *panelMessageData {
+	if panel.ChannelId == nil {
+		return nil
+	}
+
 	var emote *emoji.Emoji
 	if panel.EmojiName != nil { // No emoji = nil
 		if panel.EmojiId == nil { // Unicode emoji
@@ -42,8 +46,8 @@ func panelIntoMessageData(panel database.Panel, isPremium bool) panelMessageData
 		}
 	}
 
-	return panelMessageData{
-		ChannelId:      panel.ChannelId,
+	return &panelMessageData{
+		ChannelId:      *panel.ChannelId,
 		Title:          panel.Title,
 		Content:        panel.Content,
 		CustomId:       panel.CustomId,

--- a/app/http/endpoints/api/panel/panelresend.go
+++ b/app/http/endpoints/api/panel/panelresend.go
@@ -76,10 +76,10 @@ func ResendPanel(ctx *gin.Context) {
 		return
 	}
 
-	var msgId *uint64 = nil
+	var newMsgId *uint64
 	messageData := panelIntoMessageData(panel, premiumTier > premium.None)
 	if messageData != nil {
-		*msgId, err = messageData.send(botContext)
+		msgId, err := messageData.send(botContext)
 		if err != nil {
 			var unwrapped request.RestError
 			if errors.As(err, &unwrapped) && unwrapped.StatusCode == 403 {
@@ -90,9 +90,10 @@ func ResendPanel(ctx *gin.Context) {
 
 			return
 		}
+		newMsgId = &msgId
 	}
 
-	if err = dbclient.Client.Panel.UpdateMessageId(ctx, panel.PanelId, msgId); err != nil {
+	if err = dbclient.Client.Panel.UpdateMessageId(ctx, panel.PanelId, newMsgId); err != nil {
 		ctx.JSON(500, utils.ErrorJson(err))
 		return
 	}

--- a/app/http/endpoints/api/panel/panelresend.go
+++ b/app/http/endpoints/api/panel/panelresend.go
@@ -53,13 +53,20 @@ func ResendPanel(ctx *gin.Context) {
 		return
 	}
 
+	if panel.ChannelId == nil {
+		ctx.JSON(400, utils.ErrorStr("This panel has no selected channel."))
+		return
+	}
+
 	// delete old message
 	// TODO: Use proper context
-	if err := rest.DeleteMessage(context.Background(), botContext.Token, botContext.RateLimiter, panel.ChannelId, panel.GuildId); err != nil {
-		var unwrapped request.RestError
-		if errors.As(err, &unwrapped) && !unwrapped.IsClientError() {
-			ctx.JSON(500, utils.ErrorJson(err))
-			return
+	if panel.MessageId != nil {
+		if err := rest.DeleteMessage(context.Background(), botContext.Token, botContext.RateLimiter, *panel.ChannelId, *panel.MessageId); err != nil {
+			var unwrapped request.RestError
+			if errors.As(err, &unwrapped) && !unwrapped.IsClientError() {
+				ctx.JSON(500, utils.ErrorJson(err))
+				return
+			}
 		}
 	}
 
@@ -69,17 +76,20 @@ func ResendPanel(ctx *gin.Context) {
 		return
 	}
 
+	var msgId *uint64 = nil
 	messageData := panelIntoMessageData(panel, premiumTier > premium.None)
-	msgId, err := messageData.send(botContext)
-	if err != nil {
-		var unwrapped request.RestError
-		if errors.As(err, &unwrapped) && unwrapped.StatusCode == 403 {
-			ctx.JSON(500, utils.ErrorStr("I do not have permission to send messages in the provided channel"))
-		} else {
-			ctx.JSON(500, utils.ErrorJson(err))
-		}
+	if messageData != nil {
+		*msgId, err = messageData.send(botContext)
+		if err != nil {
+			var unwrapped request.RestError
+			if errors.As(err, &unwrapped) && unwrapped.StatusCode == 403 {
+				ctx.JSON(500, utils.ErrorStr("I do not have permission to send messages in the provided channel"))
+			} else {
+				ctx.JSON(500, utils.ErrorJson(err))
+			}
 
-		return
+			return
+		}
 	}
 
 	if err = dbclient.Client.Panel.UpdateMessageId(ctx, panel.PanelId, msgId); err != nil {

--- a/app/http/endpoints/api/panel/panelupdate.go
+++ b/app/http/endpoints/api/panel/panelupdate.go
@@ -146,7 +146,11 @@ func UpdatePanel(c *gin.Context) {
 		existing.ButtonLabel != data.ButtonLabel ||
 		existing.Disabled != data.Disabled
 
-	newMessageId := existing.MessageId
+	var newMessageId *uint64
+	if existing.ChannelId != nil && data.ChannelId != nil {
+		// old message exists and provided channel exists
+		newMessageId = existing.MessageId
+	}
 
 	if shouldUpdateMessage && existing.ChannelId != nil && existing.MessageId != nil {
 		// delete old message, ignoring error
@@ -155,7 +159,7 @@ func UpdatePanel(c *gin.Context) {
 
 		if data.MessageId != nil && data.ChannelId != nil {
 			messageData := data.IntoPanelMessageData(existing.CustomId, premiumTier > premium.None)
-			*newMessageId, err = messageData.send(botContext)
+			messageId, err := messageData.send(botContext)
 			if err != nil {
 				var unwrapped request.RestError
 				if errors.As(err, &unwrapped) {
@@ -174,6 +178,7 @@ func UpdatePanel(c *gin.Context) {
 					return
 				}
 			}
+			newMessageId = &messageId
 		}
 
 	}

--- a/app/http/endpoints/api/panel/panelupdate.go
+++ b/app/http/endpoints/api/panel/panelupdate.go
@@ -152,12 +152,14 @@ func UpdatePanel(c *gin.Context) {
 		newMessageId = existing.MessageId
 	}
 
-	if shouldUpdateMessage && existing.ChannelId != nil && existing.MessageId != nil {
-		// delete old message, ignoring error
+	if shouldUpdateMessage {
 		// TODO: Use proper context
-		_ = rest.DeleteMessage(c, botContext.Token, botContext.RateLimiter, *existing.ChannelId, *existing.MessageId)
+		if existing.ChannelId != nil && existing.MessageId != nil {
+			// delete old message, ignoring error
+			_ = rest.DeleteMessage(c, botContext.Token, botContext.RateLimiter, *existing.ChannelId, *existing.MessageId)
+		}
 
-		if data.MessageId != nil && data.ChannelId != nil {
+		if data.ChannelId != nil {
 			messageData := data.IntoPanelMessageData(existing.CustomId, premiumTier > premium.None)
 			messageId, err := messageData.send(botContext)
 			if err != nil {

--- a/app/http/endpoints/api/panel/validation.go
+++ b/app/http/endpoints/api/panel/validation.go
@@ -100,8 +100,11 @@ func validateContent(ctx PanelValidationContext) validation.ValidationFunc {
 
 func validateChannelId(ctx PanelValidationContext) validation.ValidationFunc {
 	return func() error {
+		if ctx.Data.ChannelId == nil {
+			return nil
+		}
 		for _, ch := range ctx.Channels {
-			if ch.Id == ctx.Data.ChannelId && (ch.Type == channel.ChannelTypeGuildText || ch.Type == channel.ChannelTypeGuildNews) {
+			if ch.Id == *ctx.Data.ChannelId && (ch.Type == channel.ChannelTypeGuildText || ch.Type == channel.ChannelTypeGuildNews) {
 				return nil
 			}
 		}

--- a/frontend/src/components/manage/PanelCreationForm.svelte
+++ b/frontend/src/components/manage/PanelCreationForm.svelte
@@ -99,7 +99,7 @@
 
             <div class="row">
                 <Colour col4=true label="Panel Colour" on:change={updateColour} bind:value={tempColour}/>
-                <ChannelDropdown label="Panel Channel" allowAnnouncementChannel col4 {channels} bind:value={data.channel_id}/>
+                <ChannelDropdown label="Panel Channel" withNull nullLabel={"None"} allowAnnouncementChannel col4 {channels} bind:value={data.channel_id}/>
                 <div class="col-2">
                     <div class="row" style="justify-content: flex-start; gap: 10px">
                         <div style="white-space: nowrap">

--- a/frontend/src/views/panels/Panels.svelte
+++ b/frontend/src/views/panels/Panels.svelte
@@ -41,14 +41,14 @@
                         <tbody>
                         {#each panels as panel}
                             <tr>
-                                {#if panel.channel_id == null}
+                                {#if panel.channel_id == null || panel.channel_id == "null"}
                                   <td>None</td>
                                 {:else}
                                   <td>#{channels.find((c) => c.id === panel.channel_id)?.name ?? 'Unknown Channel'}</td>
                                 {/if}
                                 <td class="max">{panel.title}</td>
                                 <td>
-                                    <Button disabled={panel.force_disabled || panel.channel_id == null}
+                                    <Button disabled={panel.force_disabled || panel.channel_id == null || panel.channel_id == "null"}
                                             on:click={() => resendPanel(panel.panel_id)}>Resend
                                     </Button>
                                 </td>

--- a/frontend/src/views/panels/Panels.svelte
+++ b/frontend/src/views/panels/Panels.svelte
@@ -41,10 +41,14 @@
                         <tbody>
                         {#each panels as panel}
                             <tr>
-                                <td>#{channels.find((c) => c.id === panel.channel_id)?.name ?? 'Unknown Channel'}</td>
+                                {#if panel.channel_id == null}
+                                  <td>None</td>
+                                {:else}
+                                  <td>#{channels.find((c) => c.id === panel.channel_id)?.name ?? 'Unknown Channel'}</td>
+                                {/if}
                                 <td class="max">{panel.title}</td>
                                 <td>
-                                    <Button disabled={panel.force_disabled}
+                                    <Button disabled={panel.force_disabled || panel.channel_id == null}
                                             on:click={() => resendPanel(panel.panel_id)}>Resend
                                     </Button>
                                 </td>


### PR DESCRIPTION
> 🚨 This pull request requires that TicketsBot-cloud/database#2 is merged.

This pull request introduces changes to handle cases where `ChannelId` and `MessageId` can be `nil`, improving robustness and error handling across the panel management backend and frontend. The most significant updates include making these fields nullable, adjusting logic to handle `nil` values gracefully, and updating the frontend to reflect these changes.

### Backend Changes:
* Made `ChannelId` and `MessageId` fields nullable in the `panelBody` and `panelMessageData` structs, and updated methods like `IntoPanelMessageData` and `panelIntoMessageData` to handle `nil` values safely. [[1]](diffhunk://#diff-3f9711437f7e2775fac0c4307ec427076ee60f62490dd0e03c97ae5e37c15f31L29-R30) [[2]](diffhunk://#diff-9e722bd087af3efabdb26133fbf06d925f755a8547637761d7c887eb6973724eL30-R34)
* Updated panel creation, deletion, and update logic to account for `nil` `ChannelId` or `MessageId`, ensuring no operations are attempted on invalid or missing data. [[1]](diffhunk://#diff-3f9711437f7e2775fac0c4307ec427076ee60f62490dd0e03c97ae5e37c15f31L88-R92) [[2]](diffhunk://#diff-43adfd3a2bc629de48de543f51b16905548cf95070765e218c73f5b70c7e3cf0L72-R80) [[3]](diffhunk://#diff-3dd0757521600550b82f1ac3954e774fd82df1dd0ae05ccd56a9e3a33b07f558L149-R164)
* Enhanced validation logic to skip validation for `nil` `ChannelId` and ensure proper handling of nullable fields.

### Frontend Changes:
* Updated `ChannelDropdown` in the panel creation form to allow a `null` value, with a "None" label to indicate no channel is selected.
* Modified the panel management view to display "None" for panels without a channel and disable the "Resend" button if `channel_id` is `null`.