### PR TITLE
feat: validation for Button Emoji and fixes

### DIFF
--- a/frontend/src/components/WrappedSelect.svelte
+++ b/frontend/src/components/WrappedSelect.svelte
@@ -17,7 +17,7 @@
         --border="#2e3136"
         --border-focused="0"
         --border-hover="0"
-        --borderRadius="4px"
+        --border-radius="4px"
         --item-hover-bg="#121212"
         --list-background="#2e3136"
         --item-color="white"

--- a/frontend/src/components/form/EmojiInput.svelte
+++ b/frontend/src/components/form/EmojiInput.svelte
@@ -33,8 +33,15 @@
 <style>
     input {
         width: 100%;
+        height: 42px;
+        margin: 0;
         border-top-right-radius: 0 !important;
         border-bottom-right-radius: 0 !important;
+    }
+
+    input:focus-visible {
+        height: 42px;
+        margin: 0;
     }
 
     .wrapper {
@@ -59,6 +66,6 @@
     }
 
     .picker-wrapper {
-        max-height: 40px;
+        max-height: 42px;
     }
 </style>

--- a/frontend/src/components/manage/PanelCreationForm.svelte
+++ b/frontend/src/components/manage/PanelCreationForm.svelte
@@ -140,7 +140,8 @@
                                         selectedValue={data.emote}
                                         optionIdentifier="id"
                                         nameMapper={emojiNameMapper}
-                                        placeholderAlwaysShow={true}
+                                        isSearchable={false}
+                                        isClearable={false}
                                         on:input={handleCustomEmojiChange} />
                             </div>
                         {:else}
@@ -218,6 +219,21 @@
     let selectedTeams = seedDefault ? [{id: 'default', name: 'Default'}] : [];
     let selectedMentions = [];
 
+    let lastCustomEmoji = undefined;
+    let lastUnicodeEmoji = '📩';
+
+    // Unicode emoji regex
+    const unicodeEmojiRegex = /^\p{Emoji}$/u;
+
+    function validateUnicodeEmoji(value) {
+        if (typeof value !== "string") return false;
+        if (/^<a?:\w+:\d+>$/.test(value)) return false;
+        // Disallow spaces
+        if (/\s/.test(value)) return false;
+        // Only allow if matches single unicode emoji
+        return unicodeEmojiRegex.test(value);
+    }
+
     // Replace spaces with dashes in naming scheme as the user types
     $: if (data.naming_scheme !== undefined && data.naming_scheme !== null && data.naming_scheme.includes(' ')) {
         data.naming_scheme = data.naming_scheme.replaceAll(' ', '-');
@@ -259,9 +275,19 @@
     function handleEmojiTypeChange(e) {
         let isCustomEmoji = e.detail;
         if (isCustomEmoji) {
-            data.emote = undefined;
+            // Restore last selected custom emoji if available, else first emoji
+            if (lastCustomEmoji) {
+                data.emote = lastCustomEmoji;
+            } else {
+                data.emote = emojis && emojis.length > 0 ? emojis[0] : undefined;
+            }
         } else {
-            data.emote = '📩';
+            // Save the current custom emoji before switching to default
+            if (data.emote && typeof data.emote === "object") {
+                lastCustomEmoji = data.emote;
+            }
+            // Restore last unicode emoji if available
+            data.emote = lastUnicodeEmoji || '📩';
         }
     }
 
@@ -271,6 +297,17 @@
             id: emoji.id,
             name: emoji.name
         };
+        lastCustomEmoji = data.emote;
+    }
+
+    // Track changes to EmojiInput (unicode emoji)
+    $: if (!data.use_custom_emoji && typeof data.emote === "string") {
+        if (validateUnicodeEmoji(data.emote)) {
+            lastUnicodeEmoji = data.emote;
+        } else {
+            // Revert to last valid unicode emoji if invalid input is detected
+            data.emote = lastUnicodeEmoji;
+        }
     }
 
     function updateColour() {
@@ -287,17 +324,17 @@
 
     function applyOverrides() {
         if (data.default_team === true) {
-            $: selectedTeams.push({id: 'default', name: 'Default'});
+            selectedTeams.push({id: 'default', name: 'Default'});
         }
 
         if (data.teams) {
-            $: data.teams
+            data.teams
                 .map((id) => teams.find((team) => team.id === id))
                 .forEach((team) => selectedTeams.push(team));
         }
 
         if (data.mentions) {
-            $: data.mentions
+            data.mentions
                 .map((id) => mentionItems.find((role) => role.id === id))
                 .forEach((mention) => selectedMentions.push(mention));
         }


### PR DESCRIPTION
This pull request introduces a mix of styling updates, input behavior adjustments, and improved emoji handling in the frontend components. The most significant changes include refining emoji input behavior, and enhancing the handling of custom and Unicode emojis

- Non-custom emoji now only accepts 1 emoji (this will still fail as normal if an emoji is used that discord does not support) (you can still copy/paste emojis)
- Custom emoji now does not allow searching (adding your own text), automatically selects the first emoji from your server
- Both saves the option you had before switching between non-custom and custom emojis
- Also fixed some annoying styling when you're switching the "modes"

https://github.com/user-attachments/assets/5e7007f4-7ae3-4490-ba5d-9cd7ac4cbbbf

^video to show how it works/looks