### PR TITLE
fix: Clearing Whitelabel Status

### DIFF
--- a/frontend/src/views/Whitelabel.svelte
+++ b/frontend/src/views/Whitelabel.svelte
@@ -44,7 +44,7 @@
                             <Button icon="fas fa-paper-plane" on:click={updateStatus} fullWidth="{true}">
                                 Submit
                             </Button>
-                            {#if bot.status_type != "0" && bot.status != ""}
+                            {#if fetched.status != ""}
                               <Button icon="fas fa-trash-can" on:click={deleteStatus} danger fullWidth="{true}">
                                 Clear Status
                               </Button>
@@ -208,6 +208,7 @@
     let active = false;
     let token;
     let bot = {};
+    let fetched = {};
     let errors = [];
 
     async function invite() {
@@ -254,7 +255,8 @@
 
             return;
         }
-
+        
+        fetched = {...data};
         notifySuccess('Updated status successfully')
     }
 
@@ -269,7 +271,14 @@
 
             return;
         }
+        
+        const blankStatus = {
+            status: "",
+            status_type: "0",
+        }
 
+        bot = blankStatus;
+        fetched = {...blankStatus};
         notifySuccess('Deleted status successfully')
     }
 
@@ -289,6 +298,7 @@
         }
 
         bot = res.data;
+        fetched = {...res.data};
 
         active = true;
 


### PR DESCRIPTION
This pull request updates the `Whitelabel.svelte` file to improve the handling of bot status by introducing a new `fetched` object. This change ensures better separation between the bot's current status and the fetched status, simplifying the logic for updating and clearing statuses.

**Enhancements to bot status handling:**

* Introduced a new `fetched` object to store the fetched bot status separately from the `bot` object. This improves data organization and avoids overwriting `bot` directly. (`frontend/src/views/Whitelabel.svelte`, [[1]](diffhunk://#diff-d93743fb24f0509c8299945444aa0de5e144b85fed70e5aea82a931f7bf0c265R211) [[2]](diffhunk://#diff-d93743fb24f0509c8299945444aa0de5e144b85fed70e5aea82a931f7bf0c265R259) [[3]](diffhunk://#diff-d93743fb24f0509c8299945444aa0de5e144b85fed70e5aea82a931f7bf0c265R301)
* Updated the conditional logic for displaying the "Clear Status" button to rely on `fetched.status` instead of `bot.status` and `bot.status_type`, simplifying the condition. (`frontend/src/views/Whitelabel.svelte`, [frontend/src/views/Whitelabel.svelteL47-R47](diffhunk://#diff-d93743fb24f0509c8299945444aa0de5e144b85fed70e5aea82a931f7bf0c265L47-R47))
* Added a `blankStatus` object to reset both `bot` and `fetched` when clearing the status, ensuring consistency in data handling. (`frontend/src/views/Whitelabel.svelte`, [frontend/src/views/Whitelabel.svelteR275-R281](diffhunk://#diff-d93743fb24f0509c8299945444aa0de5e144b85fed70e5aea82a931f7bf0c265R275-R281))