### PR TITLE
Disable 'New Panel' button when quota reached

### DIFF
--- a/frontend/src/views/panels/Panels.svelte
+++ b/frontend/src/views/panels/Panels.svelte
@@ -24,7 +24,7 @@
                     <div class="controls">
                         <p>Your panel quota: <b>{panels.length} / {isPremium ? '∞' : '3'}</b></p>
                         <Navigate to="/manage/{guildId}/panels/create" styles="link">
-                            <Button icon="fas fa-plus">New Panel</Button>
+                            <Button icon="fas fa-plus" disabled={!isPremium && panels.length >= 3}>New Panel</Button>
                         </Navigate>
                     </div>
 


### PR DESCRIPTION
The 'New Panel' button is now disabled for non-premium users who have reached the panel limit, preventing them from creating more than 3 panels.

https://ticketsv2.atlassian.net/browse/RM-135