### PR TITLE
Fix: Default max_length for String Select inputs

### DIFF
--- a/app/http/endpoints/api/forms/updateinputs.go
+++ b/app/http/endpoints/api/forms/updateinputs.go
@@ -218,6 +218,12 @@ func saveInputs(ctx context.Context, formId int, data updateInputsBody, existing
 			return fmt.Errorf("input %d does not exist", input.Id)
 		}
 
+		// For String Select (type 3), ensure max_length defaults to number of options if not set
+		maxLength := input.MaxLength
+		if input.Type == 3 && maxLength == 0 && len(input.Options) > 0 {
+			maxLength = uint16(len(input.Options))
+		}
+
 		wrapped := database.FormInput{
 			Id:          input.Id,
 			FormId:      formId,
@@ -230,7 +236,7 @@ func saveInputs(ctx context.Context, formId int, data updateInputsBody, existing
 			Placeholder: input.Placeholder,
 			Required:    input.Required,
 			MinLength:   &input.MinLength,
-			MaxLength:   &input.MaxLength,
+			MaxLength:   &maxLength,
 		}
 
 		if err := dbclient.Client.FormInput.UpdateTx(ctx, tx, wrapped); err != nil {
@@ -273,6 +279,12 @@ func saveInputs(ctx context.Context, formId int, data updateInputsBody, existing
 			return err
 		}
 
+		// For String Select (type 3), ensure max_length defaults to number of options if not set
+		maxLength := input.MaxLength
+		if input.Type == 3 && maxLength == 0 && len(input.Options) > 0 {
+			maxLength = uint16(len(input.Options))
+		}
+
 		formInputId, err := dbclient.Client.FormInput.CreateTx(ctx,
 			tx,
 			formId,
@@ -285,7 +297,7 @@ func saveInputs(ctx context.Context, formId int, data updateInputsBody, existing
 			input.Placeholder,
 			input.Required,
 			&input.MinLength,
-			&input.MaxLength,
+			&maxLength,
 		)
 
 		if err != nil {

--- a/frontend/src/components/manage/FormInputRow.svelte
+++ b/frontend/src/components/manage/FormInputRow.svelte
@@ -26,6 +26,11 @@
         data.options = [];
     }
 
+    // Set default max_length for String Select if not set
+    $: if (data.type === 3 && data.options && data.options.length > 0 && !data.max_length) {
+        data.max_length = data.options.length;
+    }
+
     // Validate min/max selections
     $: if (
         data.min_length &&
@@ -97,6 +102,10 @@
                     description: "",
                 },
             ];
+            // If max_length was not set or was equal to previous length, update it
+            if (!data.max_length || data.max_length === data.options.length - 1) {
+                data.max_length = data.options.length;
+            }
         }
     }
 

--- a/frontend/src/views/Forms.svelte
+++ b/frontend/src/views/Forms.svelte
@@ -124,6 +124,7 @@
             max_length: 255,
             is_new: true,
             type: 4, // Text Input
+            options: [], // Initialize empty options array for potential String Select
         };
 
         form.inputs = [...form.inputs, input];
@@ -185,6 +186,10 @@
                     ...i,
                     style: parseInt(i.style),
                     placeholder: nullIfBlank(i.placeholder),
+                    // Ensure String Select has max_length set to options length if not specified
+                    max_length: i.type === 3 && !i.max_length && i.options?.length > 0
+                        ? i.options.length
+                        : i.max_length,
                 })),
             update: form.inputs
                 .filter((i) => !i.is_new)
@@ -192,6 +197,10 @@
                     ...i,
                     style: parseInt(i.style),
                     placeholder: nullIfBlank(i.placeholder),
+                    // Ensure String Select has max_length set to options length if not specified
+                    max_length: i.type === 3 && !i.max_length && i.options?.length > 0
+                        ? i.options.length
+                        : i.max_length,
                 })),
             delete: toDelete[activeFormId] || [],
         };


### PR DESCRIPTION
Ensure that String Select (type 3) form inputs have their max_length property default to the number of options if not explicitly set.