### PR TITLE
Gate billing history behind pricing flag

### DIFF
--- a/backend/app/http/endpoints/api/polar/orders.go
+++ b/backend/app/http/endpoints/api/polar/orders.go
@@ -29,6 +29,11 @@ func GetOrders(ctx *gin.Context) {
 	userId := ctx.Keys["userid"].(uint64)
 	userIdStr := strconv.FormatUint(userId, 10)
 
+	if !utils.FeatureFlags.IsEnabled(ctx, "202608_NEW_PRICING_PAGE", utils.DashboardFlagAttributes(ctx, userId)) {
+		ctx.JSON(http.StatusServiceUnavailable, utils.ErrorStr("Billing history is temporarily unavailable. Please try again shortly."))
+		return
+	}
+
 	page := int64(1)
 	limit := int64(50)
 
@@ -93,6 +98,11 @@ func GetOrderInvoice(ctx *gin.Context) {
 	userId := ctx.Keys["userid"].(uint64)
 	userIdStr := strconv.FormatUint(userId, 10)
 	orderId := ctx.Param("orderid")
+
+	if !utils.FeatureFlags.IsEnabled(ctx, "202608_NEW_PRICING_PAGE", utils.DashboardFlagAttributes(ctx, userId)) {
+		ctx.JSON(http.StatusServiceUnavailable, utils.ErrorStr("Billing history is temporarily unavailable. Please try again shortly."))
+		return
+	}
 
 	// Verify the order belongs to this user by fetching it and checking the customer.
 	orderRes, err := GetPolarClient().Orders.Get(ctx, orderId)

--- a/backend/app/http/endpoints/api/user/featureflags.go
+++ b/backend/app/http/endpoints/api/user/featureflags.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/ticketsbot-cloud/dashboard/backend/app"
 	"github.com/ticketsbot-cloud/dashboard/backend/botcontext"
-	"github.com/ticketsbot-cloud/dashboard/backend/internal/admin"
 	"github.com/ticketsbot-cloud/dashboard/backend/rpc"
 	"github.com/ticketsbot-cloud/dashboard/backend/utils"
 )
@@ -33,23 +32,6 @@ var browserFlags = []string{
 	"202608_FEATURE_WHITELABEL",
 	"202608_FEATURE_INTEGRATIONS",
 	"202608_FEATURE_AUTOMATIONS",
-}
-
-// buildDashboardAttributes builds the base targeting attributes for the
-// logged-in dashboard user, bucketed on the dashboard user.
-func buildDashboardAttributes(ctx *gin.Context, userId uint64) featureflags.Attributes {
-	attributes := featureflags.ForDashboardUser(userId)
-
-	// Staff tier lets internal users see a feature before anyone else. This route
-	// is not under RequireAdminTier, so admin_tier is absent from ctx.Keys and the
-	// tier has to be looked up. That is one query per page load, not per request in
-	// a hot path, and without it every staff-targeted rule would silently never
-	// match.
-	if tier := admin.GetAdminTier(ctx, userId); tier != admin.AdminTierNone {
-		attributes = attributes.WithStaffTier(string(tier))
-	}
-
-	return attributes
 }
 
 // evalBrowserFlags evaluates the allowlisted flags against the given attributes.
@@ -81,7 +63,7 @@ func evalBrowserFlags(ctx *gin.Context, attributes featureflags.Attributes) map[
 // frontend reads them through useFeatureFlag.
 func GetFeatureFlags(ctx *gin.Context) {
 	userId := ctx.Keys["userid"].(uint64)
-	ctx.JSON(200, evalBrowserFlags(ctx, buildDashboardAttributes(ctx, userId)))
+	ctx.JSON(200, evalBrowserFlags(ctx, utils.DashboardFlagAttributes(ctx, userId)))
 }
 
 // GetGuildFeatureFlags evaluates the same browser-visible flags, scoped to a
@@ -103,7 +85,7 @@ func GetGuildFeatureFlags(ctx *gin.Context) {
 		return
 	}
 
-	attributes := buildDashboardAttributes(ctx, userId).
+	attributes := utils.DashboardFlagAttributes(ctx, userId).
 		WithGuild(guildId).
 		WithPremiumTier(int8(premiumTier))
 

--- a/backend/utils/featureflags.go
+++ b/backend/utils/featureflags.go
@@ -1,6 +1,11 @@
 package utils
 
-import "github.com/TicketsBot-cloud/common/featureflags"
+import (
+	"context"
+
+	"github.com/TicketsBot-cloud/common/featureflags"
+	"github.com/ticketsbot-cloud/dashboard/backend/internal/admin"
+)
 
 // FeatureFlags is assigned once during startup. Reading it before assignment is
 // safe: the client's methods tolerate a nil receiver, which is treated the same
@@ -9,3 +14,16 @@ var FeatureFlags *featureflags.Client
 
 // ExposureRecorder is retained so shutdown can flush whatever is queued.
 var ExposureRecorder *featureflags.Recorder
+
+// DashboardFlagAttributes builds targeting attributes for a logged-in dashboard user.
+// Handler guards must use this so their verdict matches what /user/feature-flags told the
+// browser; without the staff tier a staff-targeted feature renders and then 503s.
+func DashboardFlagAttributes(ctx context.Context, userId uint64) featureflags.Attributes {
+	attributes := featureflags.ForDashboardUser(userId)
+
+	if tier := admin.GetAdminTier(ctx, userId); tier != admin.AdminTierNone {
+		attributes = attributes.WithStaffTier(string(tier))
+	}
+
+	return attributes
+}

--- a/frontend/src/pages/premium/Subscription.tsx
+++ b/frontend/src/pages/premium/Subscription.tsx
@@ -10,6 +10,8 @@ import { toast } from "sonner";
 import { useAuthStore } from "@/stores/auth";
 import { PATREON_URL } from "@/lib/constants";
 import { formatCurrency } from "@/lib/currency";
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
+import { PRICING_FLAG } from "@/lib/feature-flags";
 import type { UserEntitlement, LegacyEntitlement, PolarSubscription, Guild } from "@/types";
 
 interface SubscriptionData {
@@ -98,6 +100,8 @@ export default function Subscription() {
   const [orders, setOrders] = useState<PolarOrder[]>([]);
   const [ordersLoading, setOrdersLoading] = useState(false);
 
+  const { enabled: billingEnabled } = useFeatureFlag(PRICING_FLAG);
+
   const loadData = useCallback(async () => {
     try {
       const res = await apiClient.premium.getEntitlements();
@@ -129,8 +133,13 @@ export default function Subscription() {
     const storedGuilds = useAuthStore.getState().guilds;
     setGuilds(storedGuilds);
     loadData();
+  }, [loadData]);
+
+  // enabled is undefined while flags load, so this waits rather than firing on the off path.
+  useEffect(() => {
+    if (!billingEnabled) return;
     loadOrders();
-  }, [loadData, loadOrders]);
+  }, [billingEnabled, loadOrders]);
 
   const handleCancel = async () => {
     if (!cancelTarget) return;
@@ -397,7 +406,7 @@ export default function Subscription() {
           </div>
         )}
         {/* Billing history */}
-        {!ordersLoading && orders.length > 0 && (
+        {billingEnabled && !ordersLoading && orders.length > 0 && (
           <div className="bg-gray-800 rounded-xl p-6">
             <h2 className="text-xl font-bold text-white mb-4">Billing History</h2>
             <Table variant="compact">


### PR DESCRIPTION
## Description
Adds server-side gating for Polar order and invoice endpoints behind `202608_NEW_PRICING_PAGE`, returning a temporary-unavailable response when disabled. Refactors dashboard feature-flag attribute building into `utils.DashboardFlagAttributes` (including staff tier) and reuses it in user feature-flag endpoints to keep browser and API evaluations consistent. On the subscription page, billing history is only fetched/rendered when the pricing flag is enabled, avoiding premature requests while flags are still loading.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
<!-- Describe the tests you ran to verify your changes -->

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
