### PR TITLE
Allow basic auto-close settings for all panels

### DIFF
--- a/backend/app/http/endpoints/api/panel/validation.go
+++ b/backend/app/http/endpoints/api/panel/validation.go
@@ -588,10 +588,6 @@ func validateAutoClose(ctx PanelValidationContext) validation.ValidationFunc {
 			return nil
 		}
 
-		if !ctx.IsPremium {
-			return nil
-		}
-
 		if ac.SinceOpenWithNoResponse < 0 {
 			return validation.NewInvalidInputError("Auto-close time cannot be negative")
 		}

--- a/frontend/src/pages/manage/panels/create.tsx
+++ b/frontend/src/pages/manage/panels/create.tsx
@@ -1114,33 +1114,33 @@ const PanelsPage: FC = () => {
         subtitle="Automatically close tickets based on inactivity"
         defaultOpen={false}
       >
+        <div className="p-6 grid gap-4 grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+          <Slider
+            label="Enable Auto Close"
+            value={panel.auto_close.enabled}
+            onChange={(e) =>
+              setPanel((prev) =>
+                prev ? { ...prev, auto_close: { ...prev.auto_close, enabled: e } } : prev,
+              )
+            }
+          />
+          <Slider
+            label="Close on User Leave"
+            value={panel.auto_close.on_user_leave}
+            disabled={!panel.auto_close.enabled}
+            onChange={(e) =>
+              setPanel((prev) =>
+                prev ? { ...prev, auto_close: { ...prev.auto_close, on_user_leave: e } } : prev,
+              )
+            }
+          />
+        </div>
         <PremiumGate
           isPremium={!!premiumState?.premium}
           feature="auto-close"
           description="Auto-close inactive tickets after a set period."
           variant="overlay"
         >
-          <div className="p-6 grid gap-4 grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-            <Slider
-              label="Enable Auto Close"
-              value={panel.auto_close.enabled}
-              onChange={(e) =>
-                setPanel((prev) =>
-                  prev ? { ...prev, auto_close: { ...prev.auto_close, enabled: e } } : prev,
-                )
-              }
-            />
-            <Slider
-              label="Close on User Leave"
-              value={panel.auto_close.on_user_leave}
-              disabled={!panel.auto_close.enabled}
-              onChange={(e) =>
-                setPanel((prev) =>
-                  prev ? { ...prev, auto_close: { ...prev.auto_close, on_user_leave: e } } : prev,
-                )
-              }
-            />
-          </div>
           <div className="p-6 grid gap-4 grid-cols-1 sm:grid-cols-1 md:grid-cols-2">
             <DurationPicker
               label="Since Open with No Response"

--- a/frontend/src/pages/manage/panels/edit.tsx
+++ b/frontend/src/pages/manage/panels/edit.tsx
@@ -1058,33 +1058,33 @@ const EditPanelsPage: FC = () => {
         subtitle="Automatically close tickets based on inactivity"
         defaultOpen={false}
       >
+        <div className="p-6 grid gap-4 grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+          <Slider
+            label="Enable Auto Close"
+            value={panel.auto_close.enabled}
+            onChange={(e) =>
+              setPanel((prev) =>
+                prev ? { ...prev, auto_close: { ...prev.auto_close, enabled: e } } : prev,
+              )
+            }
+          />
+          <Slider
+            label="Close on User Leave"
+            value={panel.auto_close.on_user_leave}
+            disabled={!panel.auto_close.enabled}
+            onChange={(e) =>
+              setPanel((prev) =>
+                prev ? { ...prev, auto_close: { ...prev.auto_close, on_user_leave: e } } : prev,
+              )
+            }
+          />
+        </div>
         <PremiumGate
           isPremium={!!premiumState?.premium}
           feature="auto-close"
           description="Auto-close inactive tickets after a set period."
           variant="overlay"
         >
-          <div className="p-6 grid gap-4 grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
-            <Slider
-              label="Enable Auto Close"
-              value={panel.auto_close.enabled}
-              onChange={(e) =>
-                setPanel((prev) =>
-                  prev ? { ...prev, auto_close: { ...prev.auto_close, enabled: e } } : prev,
-                )
-              }
-            />
-            <Slider
-              label="Close on User Leave"
-              value={panel.auto_close.on_user_leave}
-              disabled={!panel.auto_close.enabled}
-              onChange={(e) =>
-                setPanel((prev) =>
-                  prev ? { ...prev, auto_close: { ...prev.auto_close, on_user_leave: e } } : prev,
-                )
-              }
-            />
-          </div>
           <div className="p-6 grid gap-4 grid-cols-1 sm:grid-cols-1 md:grid-cols-2">
             <DurationPicker
               label="Since Open with No Response"


### PR DESCRIPTION
## Description
Moves the auto-close enable and "close on user leave" toggles outside the premium UI gate on panel create/edit pages, while keeping duration-based auto-close settings premium-only. Backend validation was also updated to remove the premium check in auto-close validation so non-premium usage of the basic options is accepted.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
