### PR TITLE
Fix: Enforce Discord embed limits across dashboard

### DIFF
--- a/backend/app/http/endpoints/api/kb/articles.go
+++ b/backend/app/http/endpoints/api/kb/articles.go
@@ -1,6 +1,7 @@
 package kb
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"github.com/TicketsBot-cloud/common/premium"
 	"github.com/TicketsBot-cloud/database"
 	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
 	"github.com/ticketsbot-cloud/dashboard/backend/app/http/audit"
 	"github.com/ticketsbot-cloud/dashboard/backend/botcontext"
 	dbclient "github.com/ticketsbot-cloud/dashboard/backend/database"
@@ -116,18 +118,9 @@ func CreateArticleHandler(ctx *gin.Context) {
 		}
 	}
 
-	// Clean embed fields
-	if body.Embed != nil {
-		cleanEmbedFields(body.Embed)
-	}
-
-	// Validate embed character count
-	if body.Embed != nil {
-		totalChars := body.Embed.TotalCharacterCount()
-		if totalChars > 6000 {
-			ctx.JSON(400, utils.ErrorStr("Total embed characters (%d) exceeds Discord's 6000 character limit", totalChars))
-			return
-		}
+	if err := cleanAndValidateEmbed(body.Embed); err != nil {
+		ctx.JSON(400, utils.ErrorStr("%s", err.Error()))
+		return
 	}
 
 	slug := generateSlug(body.Title)
@@ -238,18 +231,9 @@ func UpdateArticleHandler(ctx *gin.Context) {
 		return
 	}
 
-	// Clean embed fields
-	if body.Embed != nil {
-		cleanEmbedFields(body.Embed)
-	}
-
-	// Validate embed character count
-	if body.Embed != nil {
-		totalChars := body.Embed.TotalCharacterCount()
-		if totalChars > 6000 {
-			ctx.JSON(400, utils.ErrorStr("Total embed characters (%d) exceeds Discord's 6000 character limit", totalChars))
-			return
-		}
+	if err := cleanAndValidateEmbed(body.Embed); err != nil {
+		ctx.JSON(400, utils.ErrorStr("%s", err.Error()))
+		return
 	}
 
 	slug := generateSlug(body.Title)
@@ -463,6 +447,32 @@ func generateSlug(title string) string {
 	}
 
 	return slug
+}
+
+var validate = validator.New()
+
+// Cleans first so the min=1 tags do not reject fields submitted as "".
+func cleanAndValidateEmbed(embed *types.CustomEmbed) error {
+	if embed == nil {
+		return nil
+	}
+
+	cleanEmbedFields(embed)
+
+	if err := validate.Struct(embed); err != nil {
+		var validationErrors validator.ValidationErrors
+		if !errors.As(err, &validationErrors) {
+			return err
+		}
+
+		return fmt.Errorf("your embed contained the following errors:\n%s", utils.FormatValidationErrors(validationErrors))
+	}
+
+	if total := embed.TotalCharacterCount(); total > types.EmbedTotalCharacterLimit {
+		return fmt.Errorf("total embed characters (%d) exceeds Discord's %d character limit", total, types.EmbedTotalCharacterLimit)
+	}
+
+	return nil
 }
 
 // cleanEmbedFields converts empty strings to nil for optional embed fields.

--- a/backend/app/http/endpoints/api/panel/multipanelcreate.go
+++ b/backend/app/http/endpoints/api/panel/multipanelcreate.go
@@ -45,7 +45,7 @@ type multiPanelCreateData struct {
 	SelectMenu            bool                 `json:"select_menu"`
 	SelectMenuPlaceholder *string              `json:"select_menu_placeholder,omitempty" validate:"omitempty,max=150"`
 	Panels                []panelConfiguration `json:"panels" validate:"dive"`
-	Embed                 *types.CustomEmbed   `json:"embed" validate:"omitempty,dive"`
+	Embed                 *types.CustomEmbed   `json:"embed" validate:"omitempty"`
 }
 
 func (d *multiPanelCreateData) IntoMessageData(isPremium bool) multiPanelMessageData {

--- a/backend/app/http/endpoints/api/panel/panelcreate.go
+++ b/backend/app/http/endpoints/api/panel/panelcreate.go
@@ -43,7 +43,7 @@ type panelBody struct {
 	Colour                    uint32                            `json:"colour"`
 	CategoryId                uint64                            `json:"category_id,string"`
 	Emoji                     types.Emoji                       `json:"emote"`
-	WelcomeMessage            *types.CustomEmbed                `json:"welcome_message" validate:"omitempty,dive"`
+	WelcomeMessage            *types.CustomEmbed                `json:"welcome_message" validate:"omitempty"`
 	Mentions                  []string                          `json:"mentions"`
 	WithDefaultTeam           bool                              `json:"default_team"`
 	Teams                     []int                             `json:"teams"`

--- a/backend/app/http/endpoints/api/panel/validation.go
+++ b/backend/app/http/endpoints/api/panel/validation.go
@@ -461,6 +461,10 @@ func validateEmbed(e *types.CustomEmbed) error {
 		}
 	}
 
+	if total := e.TotalCharacterCount(); total > types.EmbedTotalCharacterLimit {
+		return validation.NewInvalidInputErrorf("Total embed characters (%d) exceeds Discord's %d character limit", total, types.EmbedTotalCharacterLimit)
+	}
+
 	return nil
 }
 

--- a/backend/app/http/endpoints/api/tags/tagcreate.go
+++ b/backend/app/http/endpoints/api/tags/tagcreate.go
@@ -27,7 +27,7 @@ type tag struct {
 	UseGuildCommand bool               `json:"use_guild_command"`
 	Content         *string            `json:"content" validate:"omitempty,min=1,max=2000"`
 	UseEmbed        bool               `json:"use_embed"`
-	Embed           *types.CustomEmbed `json:"embed" validate:"omitempty,dive"`
+	Embed           *types.CustomEmbed `json:"embed" validate:"omitempty"`
 	KBArticleId     *int               `json:"kb_article_id"`
 }
 
@@ -101,8 +101,8 @@ func CreateTag(ctx *gin.Context) {
 	// Validate total embed character count
 	if data.Embed != nil {
 		totalChars := data.Embed.TotalCharacterCount()
-		if totalChars > 6000 {
-			formatted := fmt.Sprintf("Total embed characters (%d) exceeds Discord's 6000 character limit", totalChars)
+		if totalChars > types.EmbedTotalCharacterLimit {
+			formatted := fmt.Sprintf("Total embed characters (%d) exceeds Discord's %d character limit", totalChars, types.EmbedTotalCharacterLimit)
 			ctx.JSON(400, utils.ErrorStr("%s", formatted))
 			return
 		}

--- a/backend/utils/types/customembed.go
+++ b/backend/utils/types/customembed.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"unicode/utf8"
+
 	"github.com/TicketsBot-cloud/database"
 	"github.com/TicketsBot-cloud/gdl/objects/channel/embed"
 	"github.com/ticketsbot-cloud/dashboard/backend/utils"
@@ -23,12 +25,12 @@ type CustomEmbed struct {
 	Description  *string        `json:"description" validate:"omitempty,min=1,max=4096"`
 	Url          *string        `json:"url" validate:"omitempty,max=255"`
 	Colour       Colour         `json:"colour" validate:"gte=0,lte=16777215"`
-	Author       Author         `json:"author" validate:"dive"`
+	Author       Author         `json:"author"`
 	ImageUrl     *string        `json:"image_url" validate:"omitempty,max=255"`
 	ThumbnailUrl *string        `json:"thumbnail_url" validate:"omitempty,max=255"`
-	Footer       Footer         `json:"footer" validate:"dive"`
+	Footer       Footer         `json:"footer"`
 	Timestamp    *DateTimeLocal `json:"timestamp" validate:"omitempty"`
-	Fields       []Field        `json:"fields" validate:"dive,max=25"`
+	Fields       []Field        `json:"fields" validate:"max=25,dive"` // after dive, tags apply per-element
 }
 
 type Author struct {
@@ -152,29 +154,31 @@ func (c *CustomEmbed) IntoDiscordEmbed() *embed.Embed {
 	return e
 }
 
+const EmbedTotalCharacterLimit = 6000
+
 // TotalCharacterCount returns the total number of characters in the embed
 func (c *CustomEmbed) TotalCharacterCount() int {
 	total := 0
 
 	if c.Title != nil {
-		total += len(*c.Title)
+		total += utf8.RuneCountInString(*c.Title)
 	}
 
 	if c.Description != nil {
-		total += len(*c.Description)
+		total += utf8.RuneCountInString(*c.Description)
 	}
 
 	if c.Author.Name != nil {
-		total += len(*c.Author.Name)
+		total += utf8.RuneCountInString(*c.Author.Name)
 	}
 
 	if c.Footer.Text != nil {
-		total += len(*c.Footer.Text)
+		total += utf8.RuneCountInString(*c.Footer.Text)
 	}
 
 	for _, field := range c.Fields {
-		total += len(field.Name)
-		total += len(field.Value)
+		total += utf8.RuneCountInString(field.Name)
+		total += utf8.RuneCountInString(field.Value)
 	}
 
 	return total

--- a/frontend/src/components/EmbedCharacterTotal.tsx
+++ b/frontend/src/components/EmbedCharacterTotal.tsx
@@ -1,0 +1,21 @@
+import type { FC } from "react";
+import { EMBED_LIMITS } from "@/constants/embedLimits";
+import { countEmbedCharacters, type CountableEmbed } from "@/lib/embed-characters";
+
+interface EmbedCharacterTotalProps {
+  embed: CountableEmbed;
+}
+
+const EmbedCharacterTotal: FC<EmbedCharacterTotalProps> = ({ embed }) => {
+  const total = countEmbedCharacters(embed);
+  const exceeded = total > EMBED_LIMITS.TOTAL;
+
+  return (
+    <p className={`mt-3 text-xs ${exceeded ? "text-red-400" : "text-gray-400"}`} aria-live="polite">
+      Total: {total.toLocaleString()}/{EMBED_LIMITS.TOTAL.toLocaleString()} characters
+      {exceeded && " — Discord will reject this embed"}
+    </p>
+  );
+};
+
+export default EmbedCharacterTotal;

--- a/frontend/src/components/EmbedFieldsEditor.tsx
+++ b/frontend/src/components/EmbedFieldsEditor.tsx
@@ -5,6 +5,7 @@ import Textarea from "@/components/Textarea";
 import Slider from "@/components/Slider";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { EMBED_LIMITS } from "@/constants/embedLimits";
 
 interface EmbedField {
   name: string;
@@ -28,6 +29,7 @@ const EmbedFieldsEditor: FC<EmbedFieldsEditorProps> = ({ fields, onChange }) => 
   };
 
   const addField = () => {
+    if (fields.length >= EMBED_LIMITS.FIELDS) return;
     onChange([...fields, { name: "", value: "", inline: false }]);
   };
 
@@ -42,12 +44,14 @@ const EmbedFieldsEditor: FC<EmbedFieldsEditorProps> = ({ fields, onChange }) => 
                 placeholder="Field name"
                 value={field.name}
                 onChange={(v) => updateField(i, { name: v })}
+                maxLength={EMBED_LIMITS.FIELD_NAME}
+                showCount
               />
               <Textarea
                 label="Field Value"
                 value={field.value}
                 onChange={(v) => updateField(i, { value: v })}
-                max={1024}
+                max={EMBED_LIMITS.FIELD_VALUE}
               />
             </div>
             <Button
@@ -67,9 +71,19 @@ const EmbedFieldsEditor: FC<EmbedFieldsEditorProps> = ({ fields, onChange }) => 
           />
         </div>
       ))}
-      <Button variant="secondary" onClick={addField} className="text-sm font-medium w-fit">
-        <FontAwesomeIcon icon={faPlus} /> Add Field
-      </Button>
+      <div className="flex items-center gap-3">
+        <Button
+          variant="secondary"
+          onClick={addField}
+          disabled={fields.length >= EMBED_LIMITS.FIELDS}
+          className="text-sm font-medium w-fit"
+        >
+          <FontAwesomeIcon icon={faPlus} /> Add Field
+        </Button>
+        <span className="text-xs">
+          {fields.length}/{EMBED_LIMITS.FIELDS} fields
+        </span>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/FeatureFlagRuleEditor.tsx
+++ b/frontend/src/components/FeatureFlagRuleEditor.tsx
@@ -245,6 +245,7 @@ export default function FeatureFlagRuleEditor({ rules, valueType, onChange, disa
             {ID_LIST_KINDS.includes(rule.kind) && (
               <div className="mt-3">
                 <Textarea
+                  max={1000}
                   label={`IDs (${(rule.ids ?? []).length})`}
                   value={(rule.ids ?? []).join("\n")}
                   onChange={(value) =>

--- a/frontend/src/components/TextInput.tsx
+++ b/frontend/src/components/TextInput.tsx
@@ -8,6 +8,7 @@ interface TextInputProps {
   className?: string;
   label?: string;
   maxLength?: number;
+  showCount?: boolean;
   type?: "text" | "email" | "url" | "tel" | "search" | "date";
   autoComplete?: string;
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
@@ -35,6 +36,7 @@ const TextInput: FC<TextInputProps> = (props) => {
     className,
     label,
     maxLength,
+    showCount,
     type,
     autoComplete,
     onKeyDown,
@@ -50,6 +52,8 @@ const TextInput: FC<TextInputProps> = (props) => {
   };
   const inputId = useId();
   const errorId = useId();
+  const countId = useId();
+  const withCount = showCount && maxLength !== undefined;
   const borderClass = error ? "border-red-500" : "border-neutral-600 focus-within:border-blue-500";
   return (
     <div className={`flex flex-col ${className}`}>
@@ -75,15 +79,28 @@ const TextInput: FC<TextInputProps> = (props) => {
           inputMode={inputMode}
           pattern={pattern}
           aria-describedby={
-            [descriptionId, error ? errorId : null].filter(Boolean).join(" ") || undefined
+            [descriptionId, error ? errorId : null, withCount ? countId : null]
+              .filter(Boolean)
+              .join(" ") || undefined
           }
           aria-invalid={error ? true : undefined}
         />
       </div>
-      {error && (
-        <p id={errorId} className="mt-1 text-red-400 text-xs" aria-live="polite">
-          {error}
-        </p>
+      {(error || withCount) && (
+        <div className="flex items-center justify-between">
+          {error ? (
+            <p id={errorId} className="mt-1 text-red-400 text-xs" aria-live="polite">
+              {error}
+            </p>
+          ) : (
+            <span />
+          )}
+          {withCount && (
+            <span id={countId} className="text-xs mt-1">
+              {[...value].length}/{maxLength}
+            </span>
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/Textarea.tsx
+++ b/frontend/src/components/Textarea.tsx
@@ -4,7 +4,7 @@ interface TextareaProps {
   value: string;
   onChange: (value: string) => void;
   min?: number;
-  max?: number;
+  max: number;
   disabled?: boolean;
   className?: string;
   label?: string;
@@ -15,7 +15,6 @@ interface TextareaProps {
 
 const defaultProps = {
   min: 0,
-  max: 1000,
   disabled: false,
   className: "",
   label: undefined,
@@ -64,7 +63,7 @@ const Textarea: FC<TextareaProps> = (props) => {
           <span />
         )}
         <span id={countId} className="text-xs mt-1">
-          {safeValue.length}/{max}
+          {[...safeValue].length}/{max}
         </span>
       </div>
     </div>

--- a/frontend/src/components/modals/TagEditorModal.tsx
+++ b/frontend/src/components/modals/TagEditorModal.tsx
@@ -13,6 +13,8 @@ import DateTimePicker from "@/components/DateTimePicker";
 import { useKBArticles } from "@/hooks/queries/useKB";
 import { parseEmbedTimestamp, serializeEmbedTimestamp } from "@/lib/embed-timestamp";
 import type { Tag, TagEmbed } from "@/types";
+import { EMBED_LIMITS } from "@/constants/embedLimits";
+import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
 
 interface TagEditorModalProps {
   isOpen: boolean;
@@ -269,6 +271,8 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                         placeholder="Embed title"
                         value={embed.title || ""}
                         onChange={(v) => setEmbed((prev) => ({ ...prev, title: v }))}
+                        maxLength={EMBED_LIMITS.TITLE}
+                        showCount
                       />
                       <ColourSelect
                         label="Colour"
@@ -286,7 +290,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                       label="Description"
                       value={embed.description || ""}
                       onChange={(v) => setEmbed((prev) => ({ ...prev, description: v }))}
-                      max={4096}
+                      max={EMBED_LIMITS.DESCRIPTION}
                     />
 
                     <Collapsible title="" subtitle="Author Settings" defaultOpen={false}>
@@ -300,6 +304,8 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                             author: { ...prev.author, name: v },
                           }))
                         }
+                        maxLength={EMBED_LIMITS.AUTHOR_NAME}
+                        showCount
                       />
                       <div className="pt-2 grid gap-2 grid-cols-1 md:grid-cols-2">
                         <TextInput
@@ -312,6 +318,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                               author: { ...prev.author, icon_url: v },
                             }))
                           }
+                          maxLength={EMBED_LIMITS.URL}
                         />
                         <TextInput
                           label="Author URL"
@@ -323,6 +330,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                               author: { ...prev.author, url: v },
                             }))
                           }
+                          maxLength={EMBED_LIMITS.URL}
                         />
                       </div>
                     </Collapsible>
@@ -333,17 +341,19 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                         placeholder="https://example.com/thumbnail.png"
                         value={embed.thumbnail_url || ""}
                         onChange={(v) => setEmbed((prev) => ({ ...prev, thumbnail_url: v }))}
+                        maxLength={EMBED_LIMITS.URL}
                       />
                       <TextInput
                         label="Image URL"
                         placeholder="https://example.com/image.png"
                         value={embed.image_url || ""}
                         onChange={(v) => setEmbed((prev) => ({ ...prev, image_url: v }))}
+                        maxLength={EMBED_LIMITS.URL}
                       />
                     </Collapsible>
 
                     <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-                      <TextInput
+                      <Textarea
                         label="Footer Text"
                         placeholder="e.g. Powered by Tickets.bot"
                         value={embed.footer?.text || ""}
@@ -353,6 +363,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                             footer: { ...prev.footer, text: v },
                           }))
                         }
+                        max={EMBED_LIMITS.FOOTER_TEXT}
                       />
                       <TextInput
                         label="Footer Icon URL"
@@ -364,6 +375,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                             footer: { ...prev.footer, icon_url: v },
                           }))
                         }
+                        maxLength={EMBED_LIMITS.URL}
                       />
                       <DateTimePicker
                         label="Footer Timestamp (Optional)"
@@ -383,6 +395,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                         onChange={(fields) => setEmbed((prev) => ({ ...prev, fields }))}
                       />
                     </Collapsible>
+                    <EmbedCharacterTotal embed={embed} />
                   </div>
                 )}
               </>

--- a/frontend/src/constants/embedLimits.ts
+++ b/frontend/src/constants/embedLimits.ts
@@ -1,0 +1,13 @@
+// https://docs.discord.com/developers/resources/message#embed-object
+export const EMBED_LIMITS = {
+  TITLE: 256,
+  DESCRIPTION: 4096,
+  AUTHOR_NAME: 256,
+  FOOTER_TEXT: 2048,
+  FIELD_NAME: 256,
+  FIELD_VALUE: 1024,
+  FIELDS: 25,
+  // Not a Discord limit: the width of the url columns in the embeds table.
+  URL: 255,
+  TOTAL: 6000,
+} as const;

--- a/frontend/src/lib/embed-characters.ts
+++ b/frontend/src/lib/embed-characters.ts
@@ -1,0 +1,31 @@
+type CountableField = { name?: string | null; value?: string | null };
+
+export type CountableEmbed =
+  | {
+      title?: string | null;
+      description?: string | null;
+      author?: { name?: string | null } | null;
+      footer?: { text?: string | null } | null;
+      fields?: CountableField[] | null;
+    }
+  | null
+  | undefined;
+
+const length = (value?: string | null) => (value ? [...value].length : 0);
+
+// Runes, matching the backend.
+export function countEmbedCharacters(embed: CountableEmbed): number {
+  if (!embed) return 0;
+
+  let total =
+    length(embed.title) +
+    length(embed.description) +
+    length(embed.author?.name) +
+    length(embed.footer?.text);
+
+  for (const field of embed.fields ?? []) {
+    total += length(field.name) + length(field.value);
+  }
+
+  return total;
+}

--- a/frontend/src/pages/admin/flags/_index.tsx
+++ b/frontend/src/pages/admin/flags/_index.tsx
@@ -983,6 +983,7 @@ export default function FeatureFlagsPage() {
             value={newDescription}
             onChange={setNewDescription}
             placeholder="What does this flag control?"
+            max={1000}
           />
 
           <Select

--- a/frontend/src/pages/manage/kb/create.tsx
+++ b/frontend/src/pages/manage/kb/create.tsx
@@ -20,6 +20,8 @@ import EmbedFieldsEditor from "@/components/EmbedFieldsEditor";
 import EmbedPreview from "@/components/EmbedPreview";
 import { useKBCategories, useCreateKBArticle } from "@/hooks/queries/useKB";
 import type { TagEmbed } from "@/types";
+import { EMBED_LIMITS } from "@/constants/embedLimits";
+import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
 
 const defaultEmbed: TagEmbed = {
   colour: 0x5865f2,
@@ -252,6 +254,8 @@ const CreateKBArticlePage: FC = () => {
                     placeholder="Embed title"
                     value={embed.title || ""}
                     onChange={(v) => setEmbed((prev) => ({ ...prev, title: v }))}
+                    maxLength={EMBED_LIMITS.TITLE}
+                    showCount
                   />
                   <ColourSelect
                     label="Colour"
@@ -269,7 +273,7 @@ const CreateKBArticlePage: FC = () => {
                   label="Embed Description"
                   value={embed.description || ""}
                   onChange={(v) => setEmbed((prev) => ({ ...prev, description: v }))}
-                  max={4096}
+                  max={EMBED_LIMITS.DESCRIPTION}
                 />
 
                 <Collapsible title="" subtitle="Author Settings" defaultOpen={false}>
@@ -283,6 +287,8 @@ const CreateKBArticlePage: FC = () => {
                         author: { ...prev.author, name: v },
                       }))
                     }
+                    maxLength={EMBED_LIMITS.AUTHOR_NAME}
+                    showCount
                   />
                   <div className="pt-2 grid gap-2 grid-cols-1 md:grid-cols-2">
                     <TextInput
@@ -295,6 +301,7 @@ const CreateKBArticlePage: FC = () => {
                           author: { ...prev.author, icon_url: v },
                         }))
                       }
+                      maxLength={EMBED_LIMITS.URL}
                     />
                     <TextInput
                       label="Author URL"
@@ -306,6 +313,7 @@ const CreateKBArticlePage: FC = () => {
                           author: { ...prev.author, url: v },
                         }))
                       }
+                      maxLength={EMBED_LIMITS.URL}
                     />
                   </div>
                 </Collapsible>
@@ -316,17 +324,19 @@ const CreateKBArticlePage: FC = () => {
                     placeholder="https://example.com/thumbnail.png"
                     value={embed.thumbnail_url || ""}
                     onChange={(v) => setEmbed((prev) => ({ ...prev, thumbnail_url: v }))}
+                    maxLength={EMBED_LIMITS.URL}
                   />
                   <TextInput
                     label="Image URL"
                     placeholder="https://example.com/image.png"
                     value={embed.image_url || ""}
                     onChange={(v) => setEmbed((prev) => ({ ...prev, image_url: v }))}
+                    maxLength={EMBED_LIMITS.URL}
                   />
                 </Collapsible>
 
                 <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-                  <TextInput
+                  <Textarea
                     label="Footer Text"
                     placeholder="e.g. Powered by Tickets.bot"
                     value={embed.footer?.text || ""}
@@ -336,6 +346,7 @@ const CreateKBArticlePage: FC = () => {
                         footer: { ...prev.footer, text: v },
                       }))
                     }
+                    max={EMBED_LIMITS.FOOTER_TEXT}
                   />
                   <TextInput
                     label="Footer Icon URL"
@@ -347,6 +358,7 @@ const CreateKBArticlePage: FC = () => {
                         footer: { ...prev.footer, icon_url: v },
                       }))
                     }
+                    maxLength={EMBED_LIMITS.URL}
                   />
                 </Collapsible>
 
@@ -356,6 +368,7 @@ const CreateKBArticlePage: FC = () => {
                     onChange={(fields) => setEmbed((prev) => ({ ...prev, fields }))}
                   />
                 </Collapsible>
+                <EmbedCharacterTotal embed={embed} />
               </div>
             )}
 

--- a/frontend/src/pages/manage/kb/edit.tsx
+++ b/frontend/src/pages/manage/kb/edit.tsx
@@ -21,6 +21,8 @@ import EmbedPreview from "@/components/EmbedPreview";
 import TableSkeleton from "@/components/skeletons/TableSkeleton";
 import { useKBArticle, useKBCategories, useUpdateKBArticle } from "@/hooks/queries/useKB";
 import type { TagEmbed } from "@/types";
+import { EMBED_LIMITS } from "@/constants/embedLimits";
+import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
 
 const defaultEmbed: TagEmbed = {
   colour: 0x5865f2,
@@ -321,6 +323,8 @@ const EditKBArticlePage: FC = () => {
                     placeholder="Embed title"
                     value={embed.title || ""}
                     onChange={(v) => setEmbed((prev) => ({ ...prev, title: v }))}
+                    maxLength={EMBED_LIMITS.TITLE}
+                    showCount
                   />
                   <ColourSelect
                     label="Colour"
@@ -338,7 +342,7 @@ const EditKBArticlePage: FC = () => {
                   label="Embed Description"
                   value={embed.description || ""}
                   onChange={(v) => setEmbed((prev) => ({ ...prev, description: v }))}
-                  max={4096}
+                  max={EMBED_LIMITS.DESCRIPTION}
                 />
 
                 <Collapsible title="" subtitle="Author Settings" defaultOpen={false}>
@@ -352,6 +356,8 @@ const EditKBArticlePage: FC = () => {
                         author: { ...prev.author, name: v },
                       }))
                     }
+                    maxLength={EMBED_LIMITS.AUTHOR_NAME}
+                    showCount
                   />
                   <div className="pt-2 grid gap-2 grid-cols-1 md:grid-cols-2">
                     <TextInput
@@ -364,6 +370,7 @@ const EditKBArticlePage: FC = () => {
                           author: { ...prev.author, icon_url: v },
                         }))
                       }
+                      maxLength={EMBED_LIMITS.URL}
                     />
                     <TextInput
                       label="Author URL"
@@ -375,6 +382,7 @@ const EditKBArticlePage: FC = () => {
                           author: { ...prev.author, url: v },
                         }))
                       }
+                      maxLength={EMBED_LIMITS.URL}
                     />
                   </div>
                 </Collapsible>
@@ -385,17 +393,19 @@ const EditKBArticlePage: FC = () => {
                     placeholder="https://example.com/thumbnail.png"
                     value={embed.thumbnail_url || ""}
                     onChange={(v) => setEmbed((prev) => ({ ...prev, thumbnail_url: v }))}
+                    maxLength={EMBED_LIMITS.URL}
                   />
                   <TextInput
                     label="Image URL"
                     placeholder="https://example.com/image.png"
                     value={embed.image_url || ""}
                     onChange={(v) => setEmbed((prev) => ({ ...prev, image_url: v }))}
+                    maxLength={EMBED_LIMITS.URL}
                   />
                 </Collapsible>
 
                 <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-                  <TextInput
+                  <Textarea
                     label="Footer Text"
                     placeholder="e.g. Powered by Tickets.bot"
                     value={embed.footer?.text || ""}
@@ -405,6 +415,7 @@ const EditKBArticlePage: FC = () => {
                         footer: { ...prev.footer, text: v },
                       }))
                     }
+                    max={EMBED_LIMITS.FOOTER_TEXT}
                   />
                   <TextInput
                     label="Footer Icon URL"
@@ -416,6 +427,7 @@ const EditKBArticlePage: FC = () => {
                         footer: { ...prev.footer, icon_url: v },
                       }))
                     }
+                    maxLength={EMBED_LIMITS.URL}
                   />
                 </Collapsible>
 
@@ -425,6 +437,7 @@ const EditKBArticlePage: FC = () => {
                     onChange={(fields) => setEmbed((prev) => ({ ...prev, fields }))}
                   />
                 </Collapsible>
+                <EmbedCharacterTotal embed={embed} />
               </div>
             )}
 

--- a/frontend/src/pages/manage/multipanels/create.tsx
+++ b/frontend/src/pages/manage/multipanels/create.tsx
@@ -28,6 +28,8 @@ import EmojiPicker from "@/components/EmojiPicker";
 import { sortGuildChannels } from "@/lib/guild-channels";
 import { PANEL_MESSAGE_INFO } from "@/constants/panelChannelInfo";
 import MultiPanelInfoModal from "@/components/modals/MultiPanelInfoModal";
+import { EMBED_LIMITS } from "@/constants/embedLimits";
+import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
 
 type MultiPanelDraft = Omit<MultiPanelRequest, "channel_id"> & {
   channel_id?: MultiPanelRequest["channel_id"];
@@ -314,6 +316,8 @@ const MultiPanelsPage: FC = () => {
                     prev ? { ...prev, embed: { ...prev.embed, title: e } } : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.TITLE}
+                showCount
               />
               <ColourSelect
                 label="Colour"
@@ -346,7 +350,7 @@ const MultiPanelsPage: FC = () => {
                     prev ? { ...prev, embed: { ...prev.embed, description: e } } : prev,
                   )
                 }
-                max={1000}
+                max={EMBED_LIMITS.DESCRIPTION}
               />
             </div>
 
@@ -368,6 +372,8 @@ const MultiPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.AUTHOR_NAME}
+                showCount
               />
               <div className="pt-2 grid gap-2 grid-cols-1 md:grid-cols-2">
                 <TextInput
@@ -387,6 +393,7 @@ const MultiPanelsPage: FC = () => {
                         : prev,
                     )
                   }
+                  maxLength={EMBED_LIMITS.URL}
                 />
                 <TextInput
                   label="Author URL"
@@ -405,6 +412,7 @@ const MultiPanelsPage: FC = () => {
                         : prev,
                     )
                   }
+                  maxLength={EMBED_LIMITS.URL}
                 />
               </div>
             </Collapsible>
@@ -423,6 +431,7 @@ const MultiPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
               <TextInput
                 label="Image URL"
@@ -433,10 +442,11 @@ const MultiPanelsPage: FC = () => {
                     prev ? { ...prev, embed: { ...prev.embed, image_url: e } } : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
             </Collapsible>
             <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-              <TextInput
+              <Textarea
                 label="Footer Text"
                 placeholder="e.g. Powered by TicketBot"
                 value={multiPanel.embed?.footer?.text || ""}
@@ -453,6 +463,7 @@ const MultiPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                max={EMBED_LIMITS.FOOTER_TEXT}
               />
               <TextInput
                 label="Footer Icon URL"
@@ -471,6 +482,7 @@ const MultiPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
               <DateTimePicker
                 label="Footer Timestamp (Optional)"
@@ -487,6 +499,7 @@ const MultiPanelsPage: FC = () => {
                 }
               />
             </Collapsible>
+            <EmbedCharacterTotal embed={multiPanel.embed} />
           </div>
 
           <div>

--- a/frontend/src/pages/manage/multipanels/edit.tsx
+++ b/frontend/src/pages/manage/multipanels/edit.tsx
@@ -28,6 +28,8 @@ import EmojiPicker from "@/components/EmojiPicker";
 import { sortGuildChannels } from "@/lib/guild-channels";
 import { PANEL_MESSAGE_INFO } from "@/constants/panelChannelInfo";
 import MultiPanelInfoModal from "@/components/modals/MultiPanelInfoModal";
+import { EMBED_LIMITS } from "@/constants/embedLimits";
+import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
 
 const defaultEmbed = {
   author: {},
@@ -300,6 +302,8 @@ const MultiPanelsPage: FC = () => {
                     prev ? { ...prev, embed: { ...prev.embed, title: e } } : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.TITLE}
+                showCount
               />
               <ColourSelect
                 label="Colour"
@@ -332,7 +336,7 @@ const MultiPanelsPage: FC = () => {
                     prev ? { ...prev, embed: { ...prev.embed, description: e } } : prev,
                   )
                 }
-                max={1000}
+                max={EMBED_LIMITS.DESCRIPTION}
               />
             </div>
 
@@ -354,6 +358,8 @@ const MultiPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.AUTHOR_NAME}
+                showCount
               />
               <div className="pt-2 grid gap-2 grid-cols-1 md:grid-cols-2">
                 <TextInput
@@ -373,6 +379,7 @@ const MultiPanelsPage: FC = () => {
                         : prev,
                     )
                   }
+                  maxLength={EMBED_LIMITS.URL}
                 />
                 <TextInput
                   label="Author URL"
@@ -391,6 +398,7 @@ const MultiPanelsPage: FC = () => {
                         : prev,
                     )
                   }
+                  maxLength={EMBED_LIMITS.URL}
                 />
               </div>
             </Collapsible>
@@ -409,6 +417,7 @@ const MultiPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
               <TextInput
                 label="Image URL"
@@ -419,10 +428,11 @@ const MultiPanelsPage: FC = () => {
                     prev ? { ...prev, embed: { ...prev.embed, image_url: e } } : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
             </Collapsible>
             <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-              <TextInput
+              <Textarea
                 label="Footer Text"
                 placeholder="e.g. Powered by TicketBot"
                 value={multiPanel?.embed?.footer?.text || ""}
@@ -439,6 +449,7 @@ const MultiPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                max={EMBED_LIMITS.FOOTER_TEXT}
               />
               <TextInput
                 label="Footer Icon URL"
@@ -457,6 +468,7 @@ const MultiPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
               <DateTimePicker
                 label="Footer Timestamp (Optional)"
@@ -473,6 +485,7 @@ const MultiPanelsPage: FC = () => {
                 }
               />
             </Collapsible>
+            <EmbedCharacterTotal embed={multiPanel?.embed} />
           </div>
 
           <div>

--- a/frontend/src/pages/manage/panels/create.tsx
+++ b/frontend/src/pages/manage/panels/create.tsx
@@ -49,6 +49,8 @@ import {
 import { useUnsavedChanges } from "@/hooks/useUnsavedChanges";
 import { useMutationGuard } from "@/hooks/useMutationGuard";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
+import { EMBED_LIMITS } from "@/constants/embedLimits";
+import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
 
 const PRESET_NAMING_SCHEMES = [
   "ticket-%id%",
@@ -268,6 +270,8 @@ const PanelsPage: FC = () => {
                 placeholder="e.g. Open a ticket"
                 value={panel.title || ""}
                 onChange={(e) => setPanel((prev) => (prev ? { ...prev, title: e } : prev))}
+                maxLength={80}
+                showCount
               />
               <ColourSelect
                 label="Panel Colour"
@@ -284,7 +288,7 @@ const PanelsPage: FC = () => {
                 label="Panel Content"
                 value={panel.content || ""}
                 onChange={(e) => setPanel((prev) => (prev ? { ...prev, content: e } : prev))}
-                max={1000}
+                max={EMBED_LIMITS.DESCRIPTION}
               />
             </div>
             <div className="py-2">
@@ -317,12 +321,14 @@ const PanelsPage: FC = () => {
                 placeholder="e.g. https://example.com/thumbnail.png"
                 value={panel.thumbnail_url || ""}
                 onChange={(e) => setPanel((prev) => (prev ? { ...prev, thumbnail_url: e } : prev))}
+                maxLength={EMBED_LIMITS.URL}
               />
               <TextInput
                 label="Image URL"
                 placeholder="e.g. https://example.com/image.png"
                 value={panel.image_url || ""}
                 onChange={(e) => setPanel((prev) => (prev ? { ...prev, image_url: e } : prev))}
+                maxLength={EMBED_LIMITS.URL}
               />
             </div>
             <div className="py-2 grid gap-2 grid-cols-1 md:grid-cols-2">
@@ -565,6 +571,8 @@ const PanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.TITLE}
+                showCount
               />
               <ColourSelect
                 label="Colour"
@@ -594,6 +602,7 @@ const PanelsPage: FC = () => {
                     prev ? { ...prev, welcome_message: { ...prev.welcome_message, url: e } } : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
             </div>
             <div className="py-2">
@@ -607,7 +616,7 @@ const PanelsPage: FC = () => {
                       : prev,
                   )
                 }
-                max={1000}
+                max={EMBED_LIMITS.DESCRIPTION}
               />
             </div>
 
@@ -629,6 +638,8 @@ const PanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.AUTHOR_NAME}
+                showCount
               />
               <div className="pt-2 grid gap-2 grid-cols-1 md:grid-cols-2">
                 <TextInput
@@ -648,6 +659,7 @@ const PanelsPage: FC = () => {
                         : prev,
                     )
                   }
+                  maxLength={EMBED_LIMITS.URL}
                 />
                 <TextInput
                   label="Author URL"
@@ -666,6 +678,7 @@ const PanelsPage: FC = () => {
                         : prev,
                     )
                   }
+                  maxLength={EMBED_LIMITS.URL}
                 />
               </div>
             </Collapsible>
@@ -684,6 +697,7 @@ const PanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
               <TextInput
                 label="Image URL"
@@ -696,10 +710,11 @@ const PanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
             </Collapsible>
             <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-              <TextInput
+              <Textarea
                 label="Footer Text"
                 placeholder="e.g. Powered by TicketBot"
                 value={panel.welcome_message?.footer?.text || ""}
@@ -716,6 +731,7 @@ const PanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                max={EMBED_LIMITS.FOOTER_TEXT}
               />
               <TextInput
                 label="Footer Icon URL"
@@ -734,6 +750,7 @@ const PanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
               <DateTimePicker
                 label="Footer Timestamp (Optional)"
@@ -763,6 +780,7 @@ const PanelsPage: FC = () => {
                 }
               />
             </Collapsible>
+            <EmbedCharacterTotal embed={panel.welcome_message} />
           </div>
 
           <div>

--- a/frontend/src/pages/manage/panels/edit.tsx
+++ b/frontend/src/pages/manage/panels/edit.tsx
@@ -47,6 +47,8 @@ import {
 } from "@/constants/panelChannelInfo";
 import TicketModeInfoModal from "@/components/modals/TicketModeInfoModal";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
+import { EMBED_LIMITS } from "@/constants/embedLimits";
+import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
 
 const PRESET_NAMING_SCHEMES = [
   "ticket-%id%",
@@ -189,6 +191,8 @@ const EditPanelsPage: FC = () => {
                 placeholder="e.g. Open a ticket"
                 value={panel.title || ""}
                 onChange={(e) => setPanel((prev) => (prev ? { ...prev, title: e } : prev))}
+                maxLength={80}
+                showCount
               />
               <ColourSelect
                 label="Panel Colour"
@@ -205,7 +209,7 @@ const EditPanelsPage: FC = () => {
                 label="Panel Content"
                 value={panel.content || ""}
                 onChange={(e) => setPanel((prev) => (prev ? { ...prev, content: e } : prev))}
-                max={1000}
+                max={EMBED_LIMITS.DESCRIPTION}
               />
             </div>
             <div className="py-2">
@@ -233,12 +237,14 @@ const EditPanelsPage: FC = () => {
                 placeholder="e.g. https://example.com/thumbnail.png"
                 value={panel.thumbnail_url || ""}
                 onChange={(e) => setPanel((prev) => (prev ? { ...prev, thumbnail_url: e } : prev))}
+                maxLength={EMBED_LIMITS.URL}
               />
               <TextInput
                 label="Image URL"
                 placeholder="e.g. https://example.com/image.png"
                 value={panel.image_url || ""}
                 onChange={(e) => setPanel((prev) => (prev ? { ...prev, image_url: e } : prev))}
+                maxLength={EMBED_LIMITS.URL}
               />
             </div>
             <div className="py-2 grid gap-2 grid-cols-1 md:grid-cols-2">
@@ -485,6 +491,8 @@ const EditPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.TITLE}
+                showCount
               />
               <ColourSelect
                 label="Colour"
@@ -514,6 +522,7 @@ const EditPanelsPage: FC = () => {
                     prev ? { ...prev, welcome_message: { ...prev.welcome_message, url: e } } : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
             </div>
             <div className="py-2">
@@ -527,7 +536,7 @@ const EditPanelsPage: FC = () => {
                       : prev,
                   )
                 }
-                max={1000}
+                max={EMBED_LIMITS.DESCRIPTION}
               />
             </div>
 
@@ -549,6 +558,8 @@ const EditPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.AUTHOR_NAME}
+                showCount
               />
               <div className="pt-2 grid gap-2 grid-cols-1 md:grid-cols-2">
                 <TextInput
@@ -568,6 +579,7 @@ const EditPanelsPage: FC = () => {
                         : prev,
                     )
                   }
+                  maxLength={EMBED_LIMITS.URL}
                 />
                 <TextInput
                   label="Author URL"
@@ -586,6 +598,7 @@ const EditPanelsPage: FC = () => {
                         : prev,
                     )
                   }
+                  maxLength={EMBED_LIMITS.URL}
                 />
               </div>
             </Collapsible>
@@ -604,6 +617,7 @@ const EditPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
               <TextInput
                 label="Image URL"
@@ -616,10 +630,11 @@ const EditPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
             </Collapsible>
             <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-              <TextInput
+              <Textarea
                 label="Footer Text"
                 placeholder="e.g. Powered by TicketBot"
                 value={panel.welcome_message?.footer?.text || ""}
@@ -636,6 +651,7 @@ const EditPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                max={EMBED_LIMITS.FOOTER_TEXT}
               />
               <TextInput
                 label="Footer Icon URL"
@@ -654,6 +670,7 @@ const EditPanelsPage: FC = () => {
                       : prev,
                   )
                 }
+                maxLength={EMBED_LIMITS.URL}
               />
               <DateTimePicker
                 label="Footer Timestamp (Optional)"
@@ -683,6 +700,7 @@ const EditPanelsPage: FC = () => {
                 }
               />
             </Collapsible>
+            <EmbedCharacterTotal embed={panel.welcome_message} />
           </div>
 
           <div>

--- a/frontend/src/pages/manage/setup/components/PanelsStep.tsx
+++ b/frontend/src/pages/manage/setup/components/PanelsStep.tsx
@@ -10,6 +10,7 @@ import GalleryCard from "@/components/GalleryCard";
 import CardGridSkeleton from "@/components/skeletons/CardGridSkeleton";
 import Tabs from "@/components/Tabs";
 import type { GalleryListing } from "@/types";
+import { EMBED_LIMITS } from "@/constants/embedLimits";
 
 interface PanelsStepProps {
   guildId: string;
@@ -262,7 +263,7 @@ const PanelsStep: FC<PanelsStepProps> = ({
             value={content}
             onChange={setContent}
             placeholder="Click the button below to open a support ticket."
-            max={1024}
+            max={EMBED_LIMITS.DESCRIPTION}
           />
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <Select


### PR DESCRIPTION
## Description
Adds shared embed limit constants and character counting in the frontend, including per-field max lengths, live input counters, field-count caps, and a new total embed character warning component across KB, panels, multipanels, and tag editors. On the backend, embed validation is tightened and unified (including total-character checks and cleaned optional fields), hardcoded 6000 values are replaced with a shared constant, and character counting now uses rune length to match Discord-facing behavior.
https://docs.discord.com/developers/resources/message#embed-object:~:text=should%20display%20inline-,Embed%20Limits,-To%20facilitate%20showing

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Try to make any type of embed and go over the limits (you can't).
Try to make an embed with more than 6000 characters (this will be rejected by the API).

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
