### PR TITLE
Fix: Render gallery previews with DiscordContent

### DIFF
--- a/backend/app/http/endpoints/api/admin/gallery/list.go
+++ b/backend/app/http/endpoints/api/admin/gallery/list.go
@@ -1,8 +1,10 @@
 package gallery
 
 import (
+	stdjson "encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/TicketsBot-cloud/database"
 	cache2 "github.com/TicketsBot-cloud/gdl/cache"
@@ -17,6 +19,72 @@ type adminUserData struct {
 	Id        uint64 `json:"id,string"`
 	Username  string `json:"username"`
 	AvatarUrl string `json:"avatar_url,omitempty"`
+}
+
+// Embedding database.GalleryListing instead would marshal its []byte columns as base64.
+type adminListingResponse struct {
+	Id             int                `json:"id"`
+	ListingType    string             `json:"listing_type"`
+	SubmittedUser  adminUserData      `json:"submitted_user"`
+	SourceGuildId  uint64             `json:"source_guild_id,string"`
+	Name           string             `json:"name"`
+	Description    string             `json:"description"`
+	Category       string             `json:"category"`
+	Status         string             `json:"status"`
+	ReviewNote     *string            `json:"review_note"`
+	ReviewedBy     *uint64            `json:"reviewed_by,string"`
+	ReviewedAt     *time.Time         `json:"reviewed_at"`
+	ImportCount    int                `json:"import_count"`
+	Featured       bool               `json:"featured"`
+	SnapshotData   stdjson.RawMessage `json:"snapshot_data,omitempty"`
+	Title          string             `json:"title"`
+	Content        string             `json:"content"`
+	Colour         int32              `json:"colour"`
+	ImageUrl       *string            `json:"image_url"`
+	ThumbnailUrl   *string            `json:"thumbnail_url"`
+	ButtonStyle    *int16             `json:"button_style"`
+	ButtonLabel    string             `json:"button_label"`
+	EmojiName      *string            `json:"emoji_name"`
+	WelcomeMessage stdjson.RawMessage `json:"welcome_message,omitempty"`
+	Tags           []string           `json:"tags"`
+	CreatedAt      time.Time          `json:"created_at"`
+	UpdatedAt      time.Time          `json:"updated_at"`
+}
+
+func toAdminListingResponse(l database.GalleryListing, tags []string, user adminUserData) adminListingResponse {
+	listingType := l.ListingType
+	if listingType == "" {
+		listingType = database.GalleryListingTypePanel
+	}
+
+	return adminListingResponse{
+		Id:             l.Id,
+		ListingType:    listingType,
+		SubmittedUser:  user,
+		SourceGuildId:  l.SourceGuildId,
+		Name:           l.Name,
+		Description:    l.Description,
+		Category:       l.Category,
+		Status:         string(l.Status),
+		ReviewNote:     l.ReviewNote,
+		ReviewedBy:     l.ReviewedBy,
+		ReviewedAt:     l.ReviewedAt,
+		ImportCount:    l.ImportCount,
+		Featured:       l.Featured,
+		SnapshotData:   stdjson.RawMessage(l.SnapshotData),
+		Title:          l.Title,
+		Content:        l.Content,
+		Colour:         l.Colour,
+		ImageUrl:       l.ImageUrl,
+		ThumbnailUrl:   l.ThumbnailUrl,
+		ButtonStyle:    l.ButtonStyle,
+		ButtonLabel:    l.ButtonLabel,
+		EmojiName:      l.EmojiName,
+		WelcomeMessage: stdjson.RawMessage(l.WelcomeMessage),
+		Tags:           tags,
+		CreatedAt:      l.CreatedAt,
+		UpdatedAt:      l.UpdatedAt,
+	}
 }
 
 var allowedStatuses = map[string]database.GalleryListingStatus{
@@ -95,6 +163,17 @@ func ListHandler(ctx *gin.Context) {
 		listings = filtered
 	}
 
+	listingIds := make([]int, len(listings))
+	for i, l := range listings {
+		listingIds[i] = l.Id
+	}
+
+	tagsMap, err := dbclient.Client.GalleryListingTags.GetByListings(ctx, listingIds)
+	if err != nil {
+		_ = ctx.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to fetch gallery listing tags"))
+		return
+	}
+
 	// Resolve submitter user data from cache
 	userIdSet := make(map[uint64]struct{})
 	for _, l := range listings {
@@ -115,17 +194,13 @@ func ListHandler(ctx *gin.Context) {
 		}
 	}
 
-	type listingWithUser struct {
-		database.GalleryListing
-		SubmittedUser adminUserData `json:"submitted_user"`
-	}
-
-	response := make([]listingWithUser, len(listings))
+	response := make([]adminListingResponse, len(listings))
 	for i, l := range listings {
-		response[i] = listingWithUser{
-			GalleryListing: l,
-			SubmittedUser:  resolvedUsers[l.SubmitterUserId],
+		tags := tagsMap[l.Id]
+		if tags == nil {
+			tags = make([]string, 0)
 		}
+		response[i] = toAdminListingResponse(l, tags, resolvedUsers[l.SubmitterUserId])
 	}
 
 	ctx.JSON(http.StatusOK, response)

--- a/frontend/src/components/EmbedPreview.tsx
+++ b/frontend/src/components/EmbedPreview.tsx
@@ -1,7 +1,7 @@
 import type { FC } from "react";
 import { isSafeUrl } from "@/lib/url";
 import { formatEmbedTimestampForDisplay } from "@/lib/embed-timestamp";
-import DiscordContent from "@/components/discord/DiscordContent";
+import DiscordText from "@/components/discord/DiscordText";
 import { previewAvatarUrl } from "@/lib/embed-avatar";
 
 interface EmbedField {
@@ -25,9 +25,10 @@ interface EmbedPreviewData {
 
 interface EmbedPreviewProps {
   embed: EmbedPreviewData;
+  raw?: boolean;
 }
 
-const EmbedPreview: FC<EmbedPreviewProps> = ({ embed }) => {
+const EmbedPreview: FC<EmbedPreviewProps> = ({ embed, raw = false }) => {
   const borderColor = `#${(embed.colour || 0x5865f2).toString(16).padStart(6, "0")}`;
   const footerTimestamp = formatEmbedTimestampForDisplay(embed.timestamp);
   const thumbnailUrl = previewAvatarUrl(embed.thumbnail_url);
@@ -89,9 +90,9 @@ const EmbedPreview: FC<EmbedPreviewProps> = ({ embed }) => {
               <span className="text-sm font-semibold">{embed.author.name}</span>
             </div>
           ) : null}
-          <DiscordContent content={embed.title || ""} className="text-sm font-bold" />
+          <DiscordText raw={raw} content={embed.title || ""} className="text-sm font-bold" />
           {embed.description && (
-            <DiscordContent content={embed.description} className="text-sm pt-2" />
+            <DiscordText raw={raw} content={embed.description} className="text-sm pt-2" />
           )}
           {fieldRows.length > 0 && (
             <div className="mt-2 flex flex-col gap-2">
@@ -105,8 +106,16 @@ const EmbedPreview: FC<EmbedPreviewProps> = ({ embed }) => {
                 >
                   {row.map((field, fi) => (
                     <div key={fi} className="min-w-0">
-                      <DiscordContent content={field.name} className="text-xs font-semibold" />
-                      <DiscordContent content={field.value} className="text-xs text-gray-300" />
+                      <DiscordText
+                        raw={raw}
+                        content={field.name}
+                        className="text-xs font-semibold"
+                      />
+                      <DiscordText
+                        raw={raw}
+                        content={field.value}
+                        className="text-xs text-gray-300"
+                      />
                     </div>
                   ))}
                 </div>

--- a/frontend/src/components/discord/DiscordText.tsx
+++ b/frontend/src/components/discord/DiscordText.tsx
@@ -1,0 +1,28 @@
+import type { FC } from "react";
+import DiscordContent from "./DiscordContent";
+
+interface DiscordTextProps {
+  content: string;
+  raw?: boolean;
+  className?: string;
+}
+
+const DiscordText: FC<DiscordTextProps> = ({ content, raw = false, className = "" }) => {
+  if (!raw) {
+    return <DiscordContent content={content} className={className} />;
+  }
+
+  if (!content.trim()) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`text-gray-200 leading-relaxed whitespace-pre-wrap wrap-break-word ${className}`}
+    >
+      {content}
+    </div>
+  );
+};
+
+export default DiscordText;

--- a/frontend/src/components/gallery/GalleryListingPreview.tsx
+++ b/frontend/src/components/gallery/GalleryListingPreview.tsx
@@ -1,0 +1,234 @@
+import type { FC, ReactNode } from "react";
+import DiscordText from "@/components/discord/DiscordText";
+import { parseDiscordMarkdown } from "@/lib/discord-markdown";
+import EmbedPreview from "@/components/EmbedPreview";
+import DiscordButton from "@/components/discord/container/Button";
+import type {
+  GalleryListing,
+  GalleryTagSnapshot,
+  GalleryFormSnapshot,
+  GalleryFormInputSnapshot,
+} from "@/types";
+
+const FORM_INPUT_TYPE_NAMES: Record<number, string> = {
+  3: "Dropdown",
+  4: "Text",
+  5: "User Select",
+  6: "Role Select",
+  7: "Mentionable Select",
+  8: "Channel Select",
+  21: "Radio Group",
+  22: "Checkbox Group",
+};
+
+export const GALLERY_TYPE_BADGES: Record<string, { label: string; className: string }> = {
+  panel: { label: "Panel", className: "bg-purple-600/20 text-purple-400" },
+  tag: { label: "Tag", className: "bg-teal-600/20 text-teal-400" },
+  form: { label: "Form", className: "bg-orange-600/20 text-orange-400" },
+};
+
+// Anything the parser leaves as plain text renders identically either way.
+function hasMarkdown(content: string | undefined): boolean {
+  if (!content) return false;
+
+  const source = content.replace(/\r\n?/g, "\n");
+  let plain = "";
+  for (const node of parseDiscordMarkdown(source)) {
+    if (node.type !== "text") return true;
+    plain += node.value;
+  }
+  return plain !== source;
+}
+
+// Only the text EmbedPreview and TagListingPreview pass through DiscordText.
+// Form labels and placeholders are not markdown surfaces in Discord.
+function markdownFields(listing: GalleryListing): (string | undefined)[] {
+  const listingType = listing.listing_type || "panel";
+
+  if (listingType === "form") {
+    return [];
+  }
+
+  if (listingType === "tag") {
+    const snapshot = listing.snapshot_data as GalleryTagSnapshot | undefined;
+    const embed = snapshot?.embed;
+    return [
+      snapshot?.content,
+      embed?.title,
+      embed?.description,
+      ...(embed?.fields ?? []).flatMap((field) => [field.name, field.value]),
+    ];
+  }
+
+  const welcomeMessage = listing.welcome_message;
+  return [
+    listing.title,
+    listing.content,
+    welcomeMessage?.title,
+    welcomeMessage?.description,
+    ...(welcomeMessage?.fields ?? []).flatMap((field) => [field.name, field.value]),
+  ];
+}
+
+export function listingHasMarkdown(listing: GalleryListing): boolean {
+  return markdownFields(listing).some(hasMarkdown);
+}
+
+const PreviewSection: FC<{ title: string; children: ReactNode }> = ({ title, children }) => (
+  <div className="bg-gray-800 rounded-xl p-6">
+    <h2 className="text-sm font-medium text-gray-400 mb-3 uppercase tracking-wider">{title}</h2>
+    {children}
+  </div>
+);
+
+const PanelListingPreview: FC<{ listing: GalleryListing; raw: boolean }> = ({ listing, raw }) => {
+  const welcomeMessage = listing.welcome_message;
+
+  return (
+    <>
+      <PreviewSection title="Panel Preview">
+        <EmbedPreview
+          raw={raw}
+          embed={{
+            title: listing.title,
+            description: listing.content,
+            colour: listing.colour,
+            image_url: listing.image_url,
+            thumbnail_url: listing.thumbnail_url,
+          }}
+        />
+        <div className="mt-4">
+          <DiscordButton
+            button_style={listing.button_style ?? 1}
+            label={listing.button_label || "Open Ticket"}
+            emoji={listing.emoji_name ? { name: listing.emoji_name } : undefined}
+          />
+        </div>
+      </PreviewSection>
+
+      {welcomeMessage && (
+        <PreviewSection title="Welcome Message">
+          <EmbedPreview
+            raw={raw}
+            embed={{
+              ...welcomeMessage,
+              colour: parseInt(welcomeMessage.colour, 10) || listing.colour,
+            }}
+          />
+        </PreviewSection>
+      )}
+    </>
+  );
+};
+
+const TagListingPreview: FC<{ listing: GalleryListing; raw: boolean }> = ({ listing, raw }) => {
+  const snapshot = listing.snapshot_data as GalleryTagSnapshot | undefined;
+
+  if (!snapshot) {
+    return (
+      <PreviewSection title="Tag Preview">
+        <p className="text-gray-400 text-sm">No preview data available.</p>
+      </PreviewSection>
+    );
+  }
+
+  return (
+    <PreviewSection title="Tag Preview">
+      {snapshot.content && (
+        <DiscordText
+          raw={raw}
+          content={snapshot.content}
+          className="text-gray-300 text-sm mb-4 bg-gray-900 rounded p-3"
+        />
+      )}
+      {snapshot.embed && (
+        <EmbedPreview
+          raw={raw}
+          embed={{ ...snapshot.embed, colour: snapshot.embed.colour || 0x14b8a6 }}
+        />
+      )}
+    </PreviewSection>
+  );
+};
+
+const FormInputPreviewRow: FC<{ input: GalleryFormInputSnapshot }> = ({ input }) => {
+  const typeName = FORM_INPUT_TYPE_NAMES[input.type] ?? `Type ${input.type}`;
+
+  return (
+    <div className="bg-gray-900 rounded p-3">
+      <div className="flex items-start justify-between gap-2 mb-1">
+        <span className="text-white text-sm font-medium">{input.label}</span>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-gray-400 text-xs">{typeName}</span>
+          {input.required && (
+            <span className="bg-red-600/20 text-red-400 rounded-full px-2 py-0.5 text-xs font-medium">
+              Required
+            </span>
+          )}
+        </div>
+      </div>
+      {input.description && <p className="text-gray-400 text-xs mt-1">{input.description}</p>}
+      {input.placeholder && (
+        <p className="text-gray-400 text-xs mt-1 italic">Placeholder: {input.placeholder}</p>
+      )}
+      {input.options && input.options.length > 0 && (
+        <div className="mt-2 space-y-1">
+          <p className="text-gray-400 text-xs font-medium">Options:</p>
+          {input.options.map((opt, i) => (
+            <div key={i} className="text-xs text-gray-400 pl-3">
+              &bull; {opt.label}
+              {opt.description ? ` - ${opt.description}` : ""}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const FormListingPreview: FC<{ listing: GalleryListing }> = ({ listing }) => {
+  const snapshot = listing.snapshot_data as GalleryFormSnapshot | undefined;
+
+  if (!snapshot) {
+    return (
+      <PreviewSection title="Form Preview">
+        <p className="text-gray-400 text-sm">No preview data available.</p>
+      </PreviewSection>
+    );
+  }
+
+  const sortedInputs = [...(snapshot.inputs || [])].sort((a, b) => a.position - b.position);
+
+  return (
+    <PreviewSection title="Form Preview">
+      <h3 className="text-white font-semibold text-lg mb-4">{snapshot.title}</h3>
+      {sortedInputs.length > 0 ? (
+        <div className="space-y-3">
+          {sortedInputs.map((input, i) => (
+            <FormInputPreviewRow key={i} input={input} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-gray-400 text-sm">No fields defined.</p>
+      )}
+    </PreviewSection>
+  );
+};
+
+interface GalleryListingPreviewProps {
+  listing: GalleryListing;
+  raw?: boolean;
+}
+
+const GalleryListingPreview: FC<GalleryListingPreviewProps> = ({ listing, raw = false }) => {
+  switch (listing.listing_type || "panel") {
+    case "tag":
+      return <TagListingPreview listing={listing} raw={raw} />;
+    case "form":
+      return <FormListingPreview listing={listing} />;
+    default:
+      return <PanelListingPreview listing={listing} raw={raw} />;
+  }
+};
+
+export default GalleryListingPreview;

--- a/frontend/src/components/modals/GalleryPreviewModal.tsx
+++ b/frontend/src/components/modals/GalleryPreviewModal.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useId, useState, type FC, type ReactNode } from "react";
+import DismissibleModal from "@/components/modal-primitives/DismissibleModal";
+import Tabs from "@/components/Tabs";
+import GalleryListingPreview, {
+  GALLERY_TYPE_BADGES,
+  listingHasMarkdown,
+} from "@/components/gallery/GalleryListingPreview";
+import type { GallerySubmission } from "@/types";
+
+type PreviewView = "rendered" | "raw";
+
+const PREVIEW_TABS = [
+  { key: "rendered", label: "Rendered" },
+  { key: "raw", label: "Raw" },
+];
+
+const PreviewBody: FC<{
+  listing: GallerySubmission;
+  view: PreviewView;
+  onViewChange: (view: PreviewView) => void;
+}> = ({ listing, view, onViewChange }) => {
+  if (!listingHasMarkdown(listing)) {
+    return (
+      <div className="space-y-6">
+        <GalleryListingPreview listing={listing} />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Tabs
+        tabs={PREVIEW_TABS}
+        activeTab={view}
+        onChange={(key) => onViewChange(key as PreviewView)}
+        ariaLabel="Preview format"
+        className="mb-4"
+      />
+      <div
+        role="tabpanel"
+        id={`tabpanel-${view}`}
+        aria-labelledby={`tab-${view}`}
+        className="space-y-6"
+      >
+        <GalleryListingPreview listing={listing} raw={view === "raw"} />
+      </div>
+    </>
+  );
+};
+
+const MetaRow: FC<{ label: string; children: ReactNode }> = ({ label, children }) => (
+  <div className="flex gap-2">
+    <dt className="text-gray-500 shrink-0">{label}</dt>
+    <dd className="text-gray-300 min-w-0 wrap-break-word">{children}</dd>
+  </div>
+);
+
+interface GalleryPreviewModalProps {
+  listing: GallerySubmission | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+const GalleryPreviewModal: FC<GalleryPreviewModalProps> = ({ listing, open, onClose }) => {
+  const headingId = useId();
+  const [view, setView] = useState<PreviewView>("rendered");
+
+  useEffect(() => {
+    if (open) setView("rendered");
+  }, [open, listing?.id]);
+
+  const badge = listing ? GALLERY_TYPE_BADGES[listing.listing_type || "panel"] : undefined;
+  const createdDate = listing
+    ? new Date(listing.created_at).toLocaleDateString("en-GB", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : "";
+
+  return (
+    <DismissibleModal
+      isOpen={open}
+      onClose={onClose}
+      ariaLabelledBy={headingId}
+      className="max-w-4xl max-h-[90vh] overflow-y-auto"
+    >
+      {listing && (
+        <>
+          <div className="flex items-center gap-2 flex-wrap mb-1 pr-6">
+            <h3 id={headingId} className="text-xl font-semibold text-white">
+              {listing.name}
+            </h3>
+            {badge && (
+              <span className={`${badge.className} rounded-full px-2.5 py-0.5 text-xs font-medium`}>
+                {badge.label}
+              </span>
+            )}
+          </div>
+          <p className="text-gray-400 text-sm mb-4">{listing.description}</p>
+
+          <PreviewBody listing={listing} view={view} onViewChange={setView} />
+
+          <dl className="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 text-sm">
+            <MetaRow label="Category">{listing.category}</MetaRow>
+            <MetaRow label="Status">
+              <span className="capitalize">{listing.status}</span>
+            </MetaRow>
+            <MetaRow label="Submitted by">
+              <span className="inline-flex items-center gap-1.5">
+                {listing.submitted_user.avatar_url && (
+                  <img
+                    src={listing.submitted_user.avatar_url}
+                    alt=""
+                    className="w-4 h-4 rounded-full"
+                  />
+                )}
+                {listing.submitted_user.username}
+              </span>
+            </MetaRow>
+            <MetaRow label="Submitted">{createdDate}</MetaRow>
+            <MetaRow label="Source server">{listing.source_guild_id}</MetaRow>
+            <MetaRow label="Imports">{listing.import_count}</MetaRow>
+            {listing.tags?.length > 0 && (
+              <MetaRow label="Tags">
+                <span className="flex flex-wrap gap-1.5">
+                  {listing.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="bg-gray-700 text-gray-300 rounded px-2 py-0.5 text-xs"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </span>
+              </MetaRow>
+            )}
+          </dl>
+
+          {listing.status === "rejected" && listing.review_note && (
+            <div className="mt-4 bg-red-600/10 border border-red-600/20 rounded p-3 text-sm text-red-300">
+              <span className="font-medium">Rejection reason:</span> {listing.review_note}
+            </div>
+          )}
+        </>
+      )}
+    </DismissibleModal>
+  );
+};
+
+export default GalleryPreviewModal;

--- a/frontend/src/pages/admin/gallery/_index.tsx
+++ b/frontend/src/pages/admin/gallery/_index.tsx
@@ -1,20 +1,22 @@
 import { useState, useEffect, useCallback, useId, useMemo, type FC } from "react";
 import { apiClient } from "@/lib/api";
 import { toast } from "sonner";
-import type { GallerySubmission, GalleryTagSnapshot, GalleryFormSnapshot } from "@/types";
+import type { GallerySubmission } from "@/types";
 import Button from "@/components/Button";
 import CardGridSkeleton from "@/components/skeletons/CardGridSkeleton";
 import ConfirmModal from "@/components/modals/ConfirmModal";
 import ActionModal from "@/components/modal-primitives/ActionModal";
+import GalleryPreviewModal from "@/components/modals/GalleryPreviewModal";
 import Select from "@/components/Select";
 import Slider from "@/components/Slider";
 import Tabs from "@/components/Tabs";
+import { GALLERY_TYPE_BADGES } from "@/components/gallery/GalleryListingPreview";
 import Textarea from "@/components/Textarea";
 import SearchInput from "@/components/SearchInput";
 import { useUrlSearch } from "@/hooks/useUrlSearch";
 import { matchesSearch } from "@/lib/search";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck, faXmark, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faXmark, faTrash, faEye } from "@fortawesome/free-solid-svg-icons";
 import { useAuthStore } from "@/stores/auth";
 import { isAtLeast } from "@/lib/admin-tier";
 
@@ -31,12 +33,6 @@ const TYPE_OPTIONS = [
   { key: "tag", label: "Tags" },
   { key: "form", label: "Forms" },
 ];
-
-const TYPE_BADGES: Record<string, { label: string; className: string }> = {
-  panel: { label: "Panel", className: "bg-purple-600/20 text-purple-400" },
-  tag: { label: "Tag", className: "bg-teal-600/20 text-teal-400" },
-  form: { label: "Form", className: "bg-orange-600/20 text-orange-400" },
-};
 
 const AdminGalleryPage: FC = () => {
   const { user } = useAuthStore();
@@ -55,6 +51,9 @@ const AdminGalleryPage: FC = () => {
 
   // Remove modal
   const [removeTarget, setRemoveTarget] = useState<GallerySubmission | null>(null);
+
+  // Preview modal
+  const [previewTarget, setPreviewTarget] = useState<GallerySubmission | null>(null);
 
   const fetchSubmissions = useCallback(async () => {
     setLoading(true);
@@ -194,34 +193,12 @@ const AdminGalleryPage: FC = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {filteredSubmissions.map((submission) => {
               const submissionType = submission.listing_type || "panel";
-              const typeBadge = TYPE_BADGES[submissionType];
+              const typeBadge = GALLERY_TYPE_BADGES[submissionType];
               const date = new Date(submission.created_at).toLocaleDateString("en-GB", {
                 year: "numeric",
                 month: "short",
                 day: "numeric",
               });
-
-              let previewColour: string;
-              let previewTitle: string | undefined;
-              let previewBody: string | undefined;
-
-              if (submissionType === "tag") {
-                const snap = submission.snapshot_data as GalleryTagSnapshot | undefined;
-                const embedColour = snap?.embed?.colour ?? 0x14b8a6;
-                previewColour = "#" + embedColour.toString(16).padStart(6, "0");
-                previewTitle = snap?.embed?.title;
-                previewBody = snap?.content ?? snap?.embed?.description;
-              } else if (submissionType === "form") {
-                const snap = submission.snapshot_data as GalleryFormSnapshot | undefined;
-                previewColour = "#f97316";
-                previewTitle = snap?.title;
-                const fieldCount = snap?.inputs?.length ?? 0;
-                previewBody = `${fieldCount} field${fieldCount !== 1 ? "s" : ""}`;
-              } else {
-                previewColour = "#" + submission.colour.toString(16).padStart(6, "0");
-                previewTitle = submission.title;
-                previewBody = submission.content;
-              }
 
               return (
                 <article
@@ -230,53 +207,48 @@ const AdminGalleryPage: FC = () => {
                   aria-label={`${submission.name} - ${submission.status}`}
                 >
                   <div className="p-4">
-                    {/* Mini preview */}
-                    <div
-                      className="bg-gray-900 border-l-4 rounded-r p-3 mb-3"
-                      style={{ borderLeftColor: previewColour }}
-                    >
-                      {previewTitle && (
-                        <h4 className="text-white font-semibold text-sm truncate">
-                          {previewTitle}
-                        </h4>
-                      )}
-                      {previewBody && (
-                        <p className="text-gray-400 text-xs line-clamp-2 mt-1">{previewBody}</p>
-                      )}
-                    </div>
-
-                    {/* Metadata */}
-                    <div>
-                      <h3 className="text-white font-medium truncate">{submission.name}</h3>
-                      <div className="flex items-center gap-2 mt-1 text-xs text-gray-400 flex-wrap">
-                        {typeBadge && (
-                          <span
-                            className={`${typeBadge.className} rounded-full px-2 py-0.5 font-medium`}
-                          >
-                            {typeBadge.label}
-                          </span>
-                        )}
-                        <span className="bg-blue-600/20 text-blue-400 rounded-full px-2 py-0.5">
-                          {submission.category}
-                        </span>
+                    <h3 className="text-white font-medium truncate">{submission.name}</h3>
+                    <div className="flex items-center gap-2 mt-1 text-xs text-gray-400 flex-wrap">
+                      {typeBadge && (
                         <span
-                          className={`rounded-full px-2 py-0.5 capitalize ${STATUS_BADGE[submission.status]}`}
+                          className={`${typeBadge.className} rounded-full px-2 py-0.5 font-medium`}
                         >
-                          {submission.status}
+                          {typeBadge.label}
                         </span>
-                      </div>
-                      <div className="text-xs text-gray-500 mt-1 flex items-center gap-1.5">
-                        by
-                        {submission.submitted_user.avatar_url && (
-                          <img
-                            src={submission.submitted_user.avatar_url}
-                            alt=""
-                            className="w-4 h-4 rounded-full inline"
-                          />
-                        )}
-                        {submission.submitted_user.username} &middot; {date}
-                      </div>
+                      )}
+                      <span className="bg-blue-600/20 text-blue-400 rounded-full px-2 py-0.5">
+                        {submission.category}
+                      </span>
+                      <span
+                        className={`rounded-full px-2 py-0.5 capitalize ${STATUS_BADGE[submission.status]}`}
+                      >
+                        {submission.status}
+                      </span>
                     </div>
+                    <div className="text-xs text-gray-500 mt-1 flex items-center gap-1.5">
+                      by
+                      {submission.submitted_user.avatar_url && (
+                        <img
+                          src={submission.submitted_user.avatar_url}
+                          alt=""
+                          className="w-4 h-4 rounded-full inline"
+                        />
+                      )}
+                      {submission.submitted_user.username} &middot; {date}
+                    </div>
+                  </div>
+
+                  <div className="border-t border-gray-700 px-4 py-3">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setPreviewTarget(submission)}
+                      title={`Preview ${submission.name}`}
+                      className="w-full"
+                    >
+                      <FontAwesomeIcon icon={faEye} className="mr-1" aria-hidden="true" />
+                      Preview
+                    </Button>
                   </div>
 
                   {/* Status-specific actions */}
@@ -338,6 +310,12 @@ const AdminGalleryPage: FC = () => {
           </div>
         )}
       </div>
+
+      <GalleryPreviewModal
+        listing={previewTarget}
+        open={!!previewTarget}
+        onClose={() => setPreviewTarget(null)}
+      />
 
       {/* Reject modal */}
       {canModerate && (

--- a/frontend/src/pages/gallery/view.tsx
+++ b/frontend/src/pages/gallery/view.tsx
@@ -3,17 +3,14 @@ import { useParams, Link } from "react-router";
 import { MainLayout } from "@/pages/layout/Main";
 import Button from "@/components/Button";
 import { apiClient } from "@/lib/api";
-import type {
-  GalleryListing,
-  GalleryTagSnapshot,
-  GalleryFormSnapshot,
-  GalleryFormInputSnapshot,
-} from "@/types";
+import type { GalleryListing } from "@/types";
 import GalleryImportModal from "@/components/modals/GalleryImportModal";
 import GalleryImportTagModal from "@/components/modals/GalleryImportTagModal";
 import GalleryImportFormModal from "@/components/modals/GalleryImportFormModal";
 import DetailSkeleton from "@/components/skeletons/DetailSkeleton";
-import DiscordContent from "@/components/discord/DiscordContent";
+import GalleryListingPreview, {
+  GALLERY_TYPE_BADGES,
+} from "@/components/gallery/GalleryListingPreview";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faArrowLeft,
@@ -23,268 +20,11 @@ import {
   faUser,
 } from "@fortawesome/free-solid-svg-icons";
 
-const FORM_INPUT_TYPE_NAMES: Record<number, string> = {
-  3: "Dropdown",
-  4: "Text",
-  5: "User Select",
-  6: "Role Select",
-  7: "Mentionable Select",
-  8: "Channel Select",
-  21: "Radio Group",
-  22: "Checkbox Group",
-};
-
-const TYPE_BADGES: Record<string, { label: string; className: string }> = {
-  panel: { label: "Panel", className: "bg-purple-600/20 text-purple-400" },
-  tag: { label: "Tag", className: "bg-teal-600/20 text-teal-400" },
-  form: { label: "Form", className: "bg-orange-600/20 text-orange-400" },
-};
-
 function getImportButtonLabel(type: string): string {
   if (type === "tag") return "Import Tag";
   if (type === "form") return "Import Form";
   return "Import Panel";
 }
-
-const PanelPreview: FC<{ listing: GalleryListing }> = ({ listing }) => {
-  const colourHex = "#" + listing.colour.toString(16).padStart(6, "0");
-
-  return (
-    <>
-      <div className="bg-gray-800 rounded-xl p-6">
-        <h2 className="text-sm font-medium text-gray-400 mb-3 uppercase tracking-wider">
-          Panel Preview
-        </h2>
-        <div
-          className="bg-gray-900 border-l-4 rounded-r p-4 max-w-lg"
-          style={{ borderLeftColor: colourHex }}
-        >
-          {listing.title?.trim() && (
-            <h3>
-              <DiscordContent
-                content={listing.title}
-                className="text-white font-semibold text-lg mb-2"
-              />
-            </h3>
-          )}
-          {listing.content && (
-            <DiscordContent content={listing.content} className="text-gray-300 text-sm" />
-          )}
-          {listing.image_url && (
-            <img
-              src={listing.image_url}
-              alt={`${listing.name} embed preview`}
-              className="rounded mt-3 max-w-full max-h-72 object-contain"
-            />
-          )}
-          {listing.thumbnail_url && (
-            <img
-              src={listing.thumbnail_url}
-              alt={`Thumbnail for ${listing.name}`}
-              className="rounded mt-3 w-20 h-20 object-cover"
-            />
-          )}
-        </div>
-
-        {/* Button preview */}
-        <div className="mt-4" aria-hidden="true">
-          <div
-            role="presentation"
-            className={`inline-block px-4 py-2 rounded text-sm font-medium ${
-              listing.button_style === 1
-                ? "bg-blue-600 text-white"
-                : listing.button_style === 2
-                  ? "bg-gray-600 text-white"
-                  : listing.button_style === 3
-                    ? "bg-green-600 text-white"
-                    : listing.button_style === 4
-                      ? "bg-red-600 text-white"
-                      : "bg-blue-600 text-white"
-            }`}
-          >
-            {listing.emoji_name && <span className="mr-1">{listing.emoji_name}</span>}
-            {listing.button_label || "Open Ticket"}
-          </div>
-        </div>
-      </div>
-
-      {/* Welcome message preview */}
-      {listing.welcome_message && (
-        <div className="bg-gray-800 rounded-xl p-6">
-          <h2 className="text-sm font-medium text-gray-400 mb-3 uppercase tracking-wider">
-            Welcome Message
-          </h2>
-          <div
-            className="bg-gray-900 border-l-4 rounded-r p-4 max-w-lg"
-            style={{
-              borderLeftColor: listing.welcome_message.colour
-                ? `#${parseInt(listing.welcome_message.colour).toString(16).padStart(6, "0")}`
-                : colourHex,
-            }}
-          >
-            {listing.welcome_message.title?.trim() && (
-              <h3>
-                <DiscordContent
-                  content={listing.welcome_message.title}
-                  className="text-white font-semibold text-lg mb-2"
-                />
-              </h3>
-            )}
-            {listing.welcome_message.description && (
-              <DiscordContent
-                content={listing.welcome_message.description}
-                className="text-gray-300 text-sm"
-              />
-            )}
-          </div>
-        </div>
-      )}
-    </>
-  );
-};
-
-const TagPreview: FC<{ listing: GalleryListing }> = ({ listing }) => {
-  const snapshot = listing.snapshot_data as GalleryTagSnapshot | undefined;
-  if (!snapshot) {
-    return (
-      <div className="bg-gray-800 rounded-xl p-6">
-        <h2 className="text-sm font-medium text-gray-400 mb-3 uppercase tracking-wider">
-          Tag Preview
-        </h2>
-        <p className="text-gray-400 text-sm">No preview data available.</p>
-      </div>
-    );
-  }
-
-  const embedColour = snapshot.embed?.colour ?? 0x14b8a6;
-  const colourHex = "#" + embedColour.toString(16).padStart(6, "0");
-
-  return (
-    <div className="bg-gray-800 rounded-xl p-6">
-      <h2 className="text-sm font-medium text-gray-400 mb-3 uppercase tracking-wider">
-        Tag Preview
-      </h2>
-
-      {snapshot.content && (
-        <DiscordContent
-          content={snapshot.content}
-          className="text-gray-300 text-sm mb-4 bg-gray-900 rounded p-3"
-        />
-      )}
-
-      {snapshot.embed && (
-        <div
-          className="bg-gray-900 border-l-4 rounded-r p-4 max-w-lg"
-          style={{ borderLeftColor: colourHex }}
-        >
-          {snapshot.embed.title?.trim() && (
-            <h3>
-              <DiscordContent
-                content={snapshot.embed.title}
-                className="text-white font-semibold text-lg mb-2"
-              />
-            </h3>
-          )}
-          {snapshot.embed.description && (
-            <DiscordContent
-              content={snapshot.embed.description}
-              className="text-gray-300 text-sm"
-            />
-          )}
-          {snapshot.embed.fields && snapshot.embed.fields.length > 0 && (
-            <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
-              {snapshot.embed.fields.map((field, i) => (
-                <div key={i} className={field.inline ? "" : "col-span-full"}>
-                  <DiscordContent
-                    content={field.name}
-                    className="text-white text-xs font-semibold"
-                  />
-                  <DiscordContent content={field.value} className="text-gray-400 text-xs" />
-                </div>
-              ))}
-            </div>
-          )}
-          {snapshot.embed.image_url && (
-            <img
-              src={snapshot.embed.image_url}
-              alt="Embed preview"
-              className="rounded mt-3 max-w-full max-h-72 object-contain"
-            />
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
-
-const FormInputPreviewRow: FC<{ input: GalleryFormInputSnapshot }> = ({ input }) => {
-  const typeName = FORM_INPUT_TYPE_NAMES[input.type] ?? `Type ${input.type}`;
-
-  return (
-    <div className="bg-gray-900 rounded p-3">
-      <div className="flex items-start justify-between gap-2 mb-1">
-        <span className="text-white text-sm font-medium">{input.label}</span>
-        <div className="flex items-center gap-2 shrink-0">
-          <span className="text-gray-400 text-xs">{typeName}</span>
-          {input.required && (
-            <span className="bg-red-600/20 text-red-400 rounded-full px-2 py-0.5 text-xs font-medium">
-              Required
-            </span>
-          )}
-        </div>
-      </div>
-      {input.description && <p className="text-gray-400 text-xs mt-1">{input.description}</p>}
-      {input.placeholder && (
-        <p className="text-gray-400 text-xs mt-1 italic">Placeholder: {input.placeholder}</p>
-      )}
-      {input.options && input.options.length > 0 && (
-        <div className="mt-2 space-y-1">
-          <p className="text-gray-400 text-xs font-medium">Options:</p>
-          {input.options.map((opt, i) => (
-            <div key={i} className="text-xs text-gray-400 pl-3">
-              &bull; {opt.label}
-              {opt.description ? ` - ${opt.description}` : ""}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-};
-
-const FormPreview: FC<{ listing: GalleryListing }> = ({ listing }) => {
-  const snapshot = listing.snapshot_data as GalleryFormSnapshot | undefined;
-  if (!snapshot) {
-    return (
-      <div className="bg-gray-800 rounded-xl p-6">
-        <h2 className="text-sm font-medium text-gray-400 mb-3 uppercase tracking-wider">
-          Form Preview
-        </h2>
-        <p className="text-gray-400 text-sm">No preview data available.</p>
-      </div>
-    );
-  }
-
-  const sortedInputs = [...(snapshot.inputs || [])].sort((a, b) => a.position - b.position);
-
-  return (
-    <div className="bg-gray-800 rounded-xl p-6">
-      <h2 className="text-sm font-medium text-gray-400 mb-3 uppercase tracking-wider">
-        Form Preview
-      </h2>
-      <h3 className="text-white font-semibold text-lg mb-4">{snapshot.title}</h3>
-      {sortedInputs.length > 0 ? (
-        <div className="space-y-3">
-          {sortedInputs.map((input, i) => (
-            <FormInputPreviewRow key={i} input={input} />
-          ))}
-        </div>
-      ) : (
-        <p className="text-gray-400 text-sm">No fields defined.</p>
-      )}
-    </div>
-  );
-};
 
 const GalleryViewPage: FC = () => {
   const { listingId } = useParams();
@@ -326,7 +66,7 @@ const GalleryViewPage: FC = () => {
   }
 
   const listingType = listing.listing_type || "panel";
-  const badge = TYPE_BADGES[listingType];
+  const badge = GALLERY_TYPE_BADGES[listingType];
   const createdDate = new Date(listing.created_at).toLocaleDateString("en-GB", {
     year: "numeric",
     month: "long",
@@ -348,13 +88,7 @@ const GalleryViewPage: FC = () => {
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main content */}
         <div className="lg:col-span-2 space-y-6">
-          {listingType === "tag" ? (
-            <TagPreview listing={listing} />
-          ) : listingType === "form" ? (
-            <FormPreview listing={listing} />
-          ) : (
-            <PanelPreview listing={listing} />
-          )}
+          <GalleryListingPreview listing={listing} />
         </div>
 
         {/* Sidebar */}

--- a/frontend/src/pages/gallery/view.tsx
+++ b/frontend/src/pages/gallery/view.tsx
@@ -13,6 +13,7 @@ import GalleryImportModal from "@/components/modals/GalleryImportModal";
 import GalleryImportTagModal from "@/components/modals/GalleryImportTagModal";
 import GalleryImportFormModal from "@/components/modals/GalleryImportFormModal";
 import DetailSkeleton from "@/components/skeletons/DetailSkeleton";
+import DiscordContent from "@/components/discord/DiscordContent";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faArrowLeft,
@@ -58,11 +59,16 @@ const PanelPreview: FC<{ listing: GalleryListing }> = ({ listing }) => {
           className="bg-gray-900 border-l-4 rounded-r p-4 max-w-lg"
           style={{ borderLeftColor: colourHex }}
         >
-          {listing.title && (
-            <h3 className="text-white font-semibold text-lg mb-2">{listing.title}</h3>
+          {listing.title?.trim() && (
+            <h3>
+              <DiscordContent
+                content={listing.title}
+                className="text-white font-semibold text-lg mb-2"
+              />
+            </h3>
           )}
           {listing.content && (
-            <p className="text-gray-300 text-sm whitespace-pre-wrap">{listing.content}</p>
+            <DiscordContent content={listing.content} className="text-gray-300 text-sm" />
           )}
           {listing.image_url && (
             <img
@@ -116,15 +122,19 @@ const PanelPreview: FC<{ listing: GalleryListing }> = ({ listing }) => {
                 : colourHex,
             }}
           >
-            {listing.welcome_message.title && (
-              <h3 className="text-white font-semibold text-lg mb-2">
-                {listing.welcome_message.title}
+            {listing.welcome_message.title?.trim() && (
+              <h3>
+                <DiscordContent
+                  content={listing.welcome_message.title}
+                  className="text-white font-semibold text-lg mb-2"
+                />
               </h3>
             )}
             {listing.welcome_message.description && (
-              <p className="text-gray-300 text-sm whitespace-pre-wrap">
-                {listing.welcome_message.description}
-              </p>
+              <DiscordContent
+                content={listing.welcome_message.description}
+                className="text-gray-300 text-sm"
+              />
             )}
           </div>
         </div>
@@ -156,9 +166,10 @@ const TagPreview: FC<{ listing: GalleryListing }> = ({ listing }) => {
       </h2>
 
       {snapshot.content && (
-        <p className="text-gray-300 text-sm whitespace-pre-wrap mb-4 bg-gray-900 rounded p-3">
-          {snapshot.content}
-        </p>
+        <DiscordContent
+          content={snapshot.content}
+          className="text-gray-300 text-sm mb-4 bg-gray-900 rounded p-3"
+        />
       )}
 
       {snapshot.embed && (
@@ -166,20 +177,29 @@ const TagPreview: FC<{ listing: GalleryListing }> = ({ listing }) => {
           className="bg-gray-900 border-l-4 rounded-r p-4 max-w-lg"
           style={{ borderLeftColor: colourHex }}
         >
-          {snapshot.embed.title && (
-            <h3 className="text-white font-semibold text-lg mb-2">{snapshot.embed.title}</h3>
+          {snapshot.embed.title?.trim() && (
+            <h3>
+              <DiscordContent
+                content={snapshot.embed.title}
+                className="text-white font-semibold text-lg mb-2"
+              />
+            </h3>
           )}
           {snapshot.embed.description && (
-            <p className="text-gray-300 text-sm whitespace-pre-wrap">
-              {snapshot.embed.description}
-            </p>
+            <DiscordContent
+              content={snapshot.embed.description}
+              className="text-gray-300 text-sm"
+            />
           )}
           {snapshot.embed.fields && snapshot.embed.fields.length > 0 && (
             <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
               {snapshot.embed.fields.map((field, i) => (
                 <div key={i} className={field.inline ? "" : "col-span-full"}>
-                  <p className="text-white text-xs font-semibold">{field.name}</p>
-                  <p className="text-gray-400 text-xs">{field.value}</p>
+                  <DiscordContent
+                    content={field.name}
+                    className="text-white text-xs font-semibold"
+                  />
+                  <DiscordContent content={field.value} className="text-gray-400 text-xs" />
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Description
Replace plain text rendering in gallery panel and tag previews with `DiscordContent` so titles, descriptions, and field text are formatted consistently with Discord-style content. Also avoid rendering empty headings by checking trimmed title values before displaying them.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Test if markdown render in gallery and tag previews

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
