### PR TITLE
Fix: Allow ticket openers to view transcripts

### DIFF
--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -1,4 +1,6 @@
+import { useContext } from "react";
 import { Link, useLocation, useParams } from "react-router";
+import { GuildContext } from "@/state/context";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
 
@@ -34,6 +36,9 @@ const segmentLabels: Record<string, string> = {
 export default function Breadcrumbs() {
   const location = useLocation();
   const { guildId } = useParams();
+  const guild = useContext(GuildContext);
+
+  const hasGuildAccess = !guildId || (guild?.permission_level ?? 0) >= 1;
 
   const segments = location.pathname.split("/").filter(Boolean);
 
@@ -48,7 +53,7 @@ export default function Breadcrumbs() {
     if (segment === "manage" || segment === guildId) continue;
 
     const label = segmentLabels[segment];
-    if (label) {
+    if (label && hasGuildAccess) {
       crumbs.push({ label, to: pathSoFar });
     }
   }

--- a/frontend/src/pages/manage/GuildLayout.tsx
+++ b/frontend/src/pages/manage/GuildLayout.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Outlet, useNavigate } from "react-router";
 import { GuildContext } from "@/state/context";
 import { GuildBootstrapContext } from "@/state/guildBootstrapContext";
-import { useParams } from "react-router";
+import { useMatch, useParams } from "react-router";
 import { apiClient } from "@/lib/api";
 import { getGuildById, useAuthStore } from "@/stores/auth";
 import { useGuildStore } from "@/stores/guild";
@@ -20,6 +20,8 @@ export default function GuildLayout() {
   const [verified, setVerified] = useState(false);
   const [bootstrapReady, setBootstrapReady] = useState(false);
 
+  const isTranscriptView = useMatch("/manage/:guildId/transcripts/view/:id") !== null;
+
   useEffect(() => {
     if (!guildId) {
       console.error("No guild ID provided in URL");
@@ -33,6 +35,18 @@ export default function GuildLayout() {
 
     let cancelled = false;
 
+    const enterAsTicketOpener = (level: number) => {
+      const stored = getGuildById(guildId);
+      selectGuild({
+        id: guildId,
+        name: stored?.name ?? "",
+        icon: stored?.icon,
+        permission_level: level,
+      });
+      setVerified(true);
+      setBootstrapReady(true);
+    };
+
     const verifyAndLoad = async () => {
       let serverLevel: number;
       try {
@@ -41,6 +55,10 @@ export default function GuildLayout() {
         updateGuildPermission(guildId, serverLevel);
       } catch {
         if (cancelled) return;
+        if (isTranscriptView) {
+          enterAsTicketOpener(0);
+          return;
+        }
         selectGuild(null);
         toast.error("Failed to verify permissions.");
         navigate("/", { replace: true });
@@ -49,6 +67,10 @@ export default function GuildLayout() {
 
       if (serverLevel < 1) {
         if (cancelled) return;
+        if (isTranscriptView) {
+          enterAsTicketOpener(serverLevel);
+          return;
+        }
         selectGuild(null);
         toast.warning("You do not have permission to view this page.");
         navigate("/", { replace: true });
@@ -126,7 +148,15 @@ export default function GuildLayout() {
     return () => {
       cancelled = true;
     };
-  }, [guildId, selectGuild, updateGuild, updateGuildPermission, navigate, setOnboardingState]);
+  }, [
+    guildId,
+    selectGuild,
+    updateGuild,
+    updateGuildPermission,
+    navigate,
+    setOnboardingState,
+    isTranscriptView,
+  ]);
 
   if (!verified || !bootstrapReady) {
     const guildName = selectedGuild?.name ?? getGuildById(guildId ?? "")?.name;
@@ -147,7 +177,9 @@ export default function GuildLayout() {
   return (
     <GuildBootstrapContext.Provider value={true}>
       <GuildContext.Provider value={selectedGuild == undefined ? null : selectedGuild}>
-        {guildId && <OnboardingBanner guildId={guildId} />}
+        {guildId && (selectedGuild?.permission_level ?? 0) >= 1 && (
+          <OnboardingBanner guildId={guildId} />
+        )}
         <Outlet />
       </GuildContext.Provider>
     </GuildBootstrapContext.Provider>

--- a/frontend/src/pages/manage/transcripts/view.tsx
+++ b/frontend/src/pages/manage/transcripts/view.tsx
@@ -1,7 +1,6 @@
 import { useContext, useEffect, useMemo, useState, type FC } from "react";
 import { apiClient } from "@/lib/api";
-import { useParams, Link } from "react-router";
-import { toast } from "sonner";
+import { useParams, useNavigate, Link } from "react-router";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeft, faEyeSlash, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { MainLayout } from "@/pages/layout/Main";
@@ -15,11 +14,14 @@ const TranscriptsView: FC = () => {
   guildId = guildId!;
   transcriptId = transcriptId!;
 
+  const navigate = useNavigate();
   const guild = useContext(GuildContext);
   const [transcript, setTranscript] = useState<Transcript | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [contentRestricted, setContentRestricted] = useState(false);
+
+  const canViewAllTranscripts = (guild?.permission_level ?? 0) >= 1;
 
   useEffect(() => {
     const fetchTranscript = async () => {
@@ -72,16 +74,20 @@ const TranscriptsView: FC = () => {
         };
 
         setTranscript(normalized);
-      } catch {
-        setError(true);
-        toast.error("Failed to load transcript.");
+      } catch (err) {
+        const res = (err as { response?: { status?: number; data?: { error?: string } } }).response;
+        if (res?.status === 403) {
+          navigate("/", { replace: true });
+          return;
+        }
+        setError(res?.data?.error ?? "Failed to load transcript. Please try again.");
       } finally {
         setLoading(false);
       }
     };
 
     fetchTranscript();
-  }, [guildId, transcriptId]);
+  }, [guildId, transcriptId, navigate]);
 
   const entities = useMemo(() => {
     if (!transcript) return null;
@@ -94,15 +100,17 @@ const TranscriptsView: FC = () => {
 
   return (
     <MainLayout title={`Transcript #${transcriptId}`}>
-      <div className="mb-4">
-        <Link
-          to={`/manage/${guildId}/transcripts`}
-          className="flex items-center gap-2 text-sm text-gray-400 hover:text-white transition-colors cursor-pointer"
-        >
-          <FontAwesomeIcon icon={faArrowLeft} />
-          Back to transcripts
-        </Link>
-      </div>
+      {canViewAllTranscripts && (
+        <div className="mb-4">
+          <Link
+            to={`/manage/${guildId}/transcripts`}
+            className="flex items-center gap-2 text-sm text-gray-400 hover:text-white transition-colors cursor-pointer"
+          >
+            <FontAwesomeIcon icon={faArrowLeft} />
+            Back to transcripts
+          </Link>
+        </div>
+      )}
 
       {loading && (
         <div className="flex items-center justify-center py-16 text-gray-400">
@@ -112,9 +120,7 @@ const TranscriptsView: FC = () => {
       )}
 
       {!loading && error && (
-        <div className="flex items-center justify-center py-16 text-gray-400">
-          Failed to load transcript. Please try again.
-        </div>
+        <div className="flex items-center justify-center py-16 text-gray-400">{error}</div>
       )}
 
       {!loading && !error && contentRestricted && (

--- a/frontend/src/router/routes/guild.tsx
+++ b/frontend/src/router/routes/guild.tsx
@@ -33,7 +33,7 @@ import {
   ViewIntegrationPage,
 } from "@/router/lazy-pages";
 import { LegacyEditMultiPanelRedirect, SiblingRouteRedirect } from "@/router/redirects/components";
-import { guildPage } from "@/router/wrap";
+import { guildPage, lazyPage } from "@/router/wrap";
 
 /** Child routes under `/manage/:guildId`. */
 export const guildRoutes: RouteObject[] = [
@@ -44,7 +44,7 @@ export const guildRoutes: RouteObject[] = [
     path: "transcripts",
     children: [
       { path: "", element: guildPage(1, <TranscriptsIndex />) },
-      { path: "view/:id", element: guildPage(1, <TranscriptsView />) },
+      { path: "view/:id", element: lazyPage(<TranscriptsView />) },
     ],
   },
   {


### PR DESCRIPTION
## Description
Relax transcript view routing so `/manage/:guildId/transcripts/view/:id` no longer requires the global level-1 guild gate, and update `GuildLayout` to permit opener access on that route while still preserving existing staff-only checks elsewhere. UI elements tied to staff access (breadcrumbs, onboarding banner, transcript index back-link) are now conditionally hidden for non-staff viewers, and transcript fetch errors are shown inline without duplicate toast notifications.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Make a ticket with a user who does not have any permissions in the guild on Bot Helper/Admin  
Close and view the transcript  
Open the same link from another account that does not have any permissions either and isn't the ticket opener  
You should be redirected as normal

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
