### PR TITLE
Fix: Surface API error details on pages with custom error handling

### DIFF
--- a/frontend/src/components/modals/ErrorDetailModal.tsx
+++ b/frontend/src/components/modals/ErrorDetailModal.tsx
@@ -28,6 +28,7 @@ const ErrorDetailModal: FC = () => {
       message: details?.message,
       ...(details?.apiError &&
         details.apiError !== details?.message && { apiError: details.apiError }),
+      ...(details?.internalError && { internalError: details.internalError }),
       ...(userId && { userId }),
       ...(guildId && { guildId }),
       page: window.location.pathname,
@@ -91,6 +92,17 @@ const ErrorDetailModal: FC = () => {
               </span>
             </div>
           )}
+
+          {details?.internalError &&
+            details.internalError !== details.apiError &&
+            details.internalError !== details.message && (
+              <div className="flex items-start gap-3 bg-gray-700/50 rounded-lg px-3 py-2">
+                <span className="text-xs text-gray-400 w-24 shrink-0 pt-0.5">Internal Error</span>
+                <span className="text-sm font-mono text-gray-400 break-all whitespace-pre-wrap max-h-32 overflow-y-auto">
+                  {details.internalError}
+                </span>
+              </div>
+            )}
         </div>
 
         <div className="mt-5">

--- a/frontend/src/hooks/useApiErrorHandler.ts
+++ b/frontend/src/hooks/useApiErrorHandler.ts
@@ -1,0 +1,28 @@
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { readApiError, showApiErrorToast } from "@/lib/api-error";
+
+/**
+ * A 503 means a FEATURE_* switch flipped mid-session, which useFeatureLock's
+ * polled value won't reflect until its next tick, so force the lock here.
+ *
+ * Pass the useState setter itself: its stable identity keeps the returned
+ * handler stable enough to list in other hooks' dependency arrays.
+ */
+export function useApiErrorHandler(
+  unavailableMessage: string,
+  setForcedLock: (locked: boolean) => void,
+): (error: unknown, fallbackMessage: string) => void {
+  return useCallback(
+    (error: unknown, fallbackMessage: string) => {
+      const { status, message } = readApiError(error);
+      if (status === 503) {
+        toast.warning(message ?? unavailableMessage);
+        setForcedLock(true);
+        return;
+      }
+      showApiErrorToast(error, fallbackMessage);
+    },
+    [unavailableMessage, setForcedLock],
+  );
+}

--- a/frontend/src/lib/api-error.ts
+++ b/frontend/src/lib/api-error.ts
@@ -1,0 +1,85 @@
+import type { AxiosError } from "axios";
+import { toast } from "sonner";
+import { useErrorModalStore, type ErrorDetails } from "@/stores/errorModal";
+
+export interface ApiErrorInfo {
+  status?: number;
+  message?: string;
+  internalError?: string;
+}
+
+export function readApiError(error: unknown): ApiErrorInfo {
+  const response = (error as AxiosError | undefined)?.response;
+  const data = response?.data as { error?: string; internal_error?: string } | undefined;
+  return {
+    status: response?.status,
+    // Empty strings collapse to undefined so a fallback still wins.
+    message: data?.error || undefined,
+    internalError: data?.internal_error || undefined,
+  };
+}
+
+const STATUS_MESSAGES: Record<number, string> = {
+  402: "This feature requires a premium subscription.",
+  403: "You don't have permission to perform this action.",
+  404: "The requested resource was not found.",
+  429: "Too many requests. Please wait a moment and try again.",
+  500: "Server error. Please try again later.",
+  503: "Service unavailable. Please try again later.",
+};
+
+/**
+ * `fallback` replaces only the per-status default. Transport failures and 401
+ * outrank it: 401 triggers a logout, so a caller's copy would contradict the
+ * redirect that follows.
+ */
+export function resolveErrorMessage(error: unknown, fallback?: string): string {
+  const axiosError = error as AxiosError | undefined;
+
+  if (axiosError?.code === "ECONNABORTED") return "Request timed out. Please try again.";
+
+  const response = axiosError?.response;
+  if (!response) {
+    if (axiosError?.request) return "Network error. Please check your connection.";
+    return fallback ?? "An unexpected error occurred";
+  }
+
+  const { status } = response;
+  if (status === 401) return "Authentication failed. Please log in again.";
+
+  const { message: apiError } = readApiError(error);
+  return apiError ?? fallback ?? STATUS_MESSAGES[status] ?? `Request failed with status ${status}`;
+}
+
+// A counter, not Date.now(): two failures in the same millisecond would share an
+// id, and the Details action would then pin the wrong toast open.
+let toastSeq = 0;
+
+/** The error toast plus the "Details" action that opens ErrorDetailModal. */
+export function showApiErrorToast(error: unknown, fallback?: string): void {
+  const { status, message: apiError, internalError } = readApiError(error);
+  const errorMessage = resolveErrorMessage(error, fallback);
+  const config = (error as AxiosError | undefined)?.config;
+
+  const toastId = `error-${++toastSeq}`;
+  const details: ErrorDetails = {
+    status,
+    message: errorMessage,
+    apiError,
+    internalError,
+    requestUrl: config?.url,
+    requestMethod: config?.method,
+  };
+
+  toast.error(errorMessage, {
+    id: toastId,
+    action: {
+      label: "Details",
+      onClick: (event) => {
+        event.preventDefault();
+        toast.error(errorMessage, { id: toastId, duration: Infinity });
+        useErrorModalStore.getState().open(details, toastId);
+      },
+    },
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,7 @@ import axios, { type AxiosError, type AxiosRequestConfig } from "axios";
 import { toast } from "sonner";
 import { API_URL } from "@/lib/constants";
 import { useAuthStore } from "@/stores/auth";
-import { useErrorModalStore } from "@/stores/errorModal";
+import { showApiErrorToast } from "@/lib/api-error";
 import { router } from "@/router";
 import type {
   User,
@@ -160,44 +160,12 @@ api.interceptors.response.use(
     if ((error.config as RequestSlotConfig | undefined)?._requestSlot) {
       releaseRequestSlot();
     }
-    const apiError = (error.response?.data as { error?: string })?.error;
 
-    let errorMessage = "An unexpected error occurred";
-    let shouldRedirect = false;
-
-    if (error.code === "ECONNABORTED") {
-      errorMessage = "Request timed out. Please try again.";
-    } else if (error.response) {
-      const status = error.response.status;
-      switch (status) {
-        case 401:
-          errorMessage = "Authentication failed. Please log in again.";
-          useAuthStore.getState().logout();
-          shouldRedirect = true;
-          break;
-        case 402:
-          errorMessage = apiError || "This feature requires a premium subscription.";
-          break;
-        case 403:
-          errorMessage = apiError || "You don't have permission to perform this action.";
-          break;
-        case 404:
-          errorMessage = apiError || "The requested resource was not found.";
-          break;
-        case 429:
-          errorMessage = apiError || "Too many requests. Please wait a moment and try again.";
-          break;
-        case 500:
-          errorMessage = apiError || "Server error. Please try again later.";
-          break;
-        case 503:
-          errorMessage = apiError || "Service unavailable. Please try again later.";
-          break;
-        default:
-          errorMessage = apiError || `Request failed with status ${status}`;
-      }
-    } else if (error.request) {
-      errorMessage = "Network error. Please check your connection.";
+    if (error.response?.status === 401) {
+      useAuthStore.getState().logout();
+      setTimeout(() => {
+        router.navigate("/");
+      }, 2000);
     }
 
     // Bulk endpoints and opted-out callers manage their own error UI - skip the global toast
@@ -207,32 +175,7 @@ api.interceptors.response.use(
       (error.config as SkipErrorToastConfig | undefined)?._skipErrorToast === true;
 
     if (!skipToast) {
-      const toastId = `error-${Date.now()}`;
-      const details = {
-        status: error.response?.status,
-        message: errorMessage,
-        apiError,
-        requestUrl: error.config?.url,
-        requestMethod: error.config?.method,
-      };
-
-      toast.error(errorMessage, {
-        id: toastId,
-        action: {
-          label: "Details",
-          onClick: (event) => {
-            event.preventDefault();
-            toast.error(errorMessage, { id: toastId, duration: Infinity });
-            useErrorModalStore.getState().open(details, toastId);
-          },
-        },
-      });
-    }
-
-    if (shouldRedirect) {
-      setTimeout(() => {
-        router.navigate("/");
-      }, 2000);
+      showApiErrorToast(error);
     }
 
     return Promise.reject(error);

--- a/frontend/src/pages/Whitelabel.tsx
+++ b/frontend/src/pages/Whitelabel.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_WHITELABEL } from "@/lib/feature-flags";
 import type { WhitelabelBot, WhitelabelError } from "@/types";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const statusTypeOptions = [
   { key: "0", label: "Playing" },
@@ -41,6 +42,10 @@ export default function Whitelabel() {
   // of dashboard users, and the environment toggle can ever match here.
   const { locked: polledLock } = useFeatureLock(FEATURE_WHITELABEL);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Whitelabel changes are temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // This page is a long-lived settings screen rather than a form the user
@@ -123,21 +128,10 @@ export default function Whitelabel() {
         );
       }
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ?? "Whitelabel changes are temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every status,
-        // not just 503, so every other failure needs its own here.
-        toast.error(
-          apiError ?? "Failed to start whitelabel. Please check your bot token and try again.",
-        );
-      }
+      handleApiError(
+        error,
+        "Failed to start whitelabel. Please check your bot token and try again.",
+      );
       console.error("Failed to start whitelabel:", error);
     }
   };
@@ -169,17 +163,7 @@ export default function Whitelabel() {
         console.error("Failed to refresh server count after resync:", reloadError);
       }
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ?? "Whitelabel changes are temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        toast.error(apiError ?? "Failed to resync bot. Please try again.");
-      }
+      handleApiError(error, "Failed to resync bot. Please try again.");
       console.error("Failed to resync bot:", error);
     } finally {
       setIsResyncing(false);
@@ -193,17 +177,7 @@ export default function Whitelabel() {
       setActive(false);
       toast.success("Whitelabel has been disabled");
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ?? "Whitelabel changes are temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        toast.error(apiError ?? "Failed to disable whitelabel. Please try again.");
-      }
+      handleApiError(error, "Failed to disable whitelabel. Please try again.");
       console.error("Failed to disable whitelabel:", error);
     }
   };
@@ -214,17 +188,7 @@ export default function Whitelabel() {
       setFetchedStatus(bot.status);
       toast.success("Updated status successfully");
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ?? "Whitelabel changes are temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        toast.error(apiError ?? "Failed to update status. Please try again.");
-      }
+      handleApiError(error, "Failed to update status. Please try again.");
       console.error("Failed to update status:", error);
     }
   };
@@ -236,17 +200,7 @@ export default function Whitelabel() {
       setFetchedStatus("");
       toast.success("Deleted status successfully");
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ?? "Whitelabel changes are temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        toast.error(apiError ?? "Failed to delete status. Please try again.");
-      }
+      handleApiError(error, "Failed to delete status. Please try again.");
       console.error("Failed to delete status:", error);
     }
   };

--- a/frontend/src/pages/manage/blacklist/_index.tsx
+++ b/frontend/src/pages/manage/blacklist/_index.tsx
@@ -21,6 +21,7 @@ import TableSkeleton from "@/components/skeletons/TableSkeleton";
 import FeatureLockBanner from "@/components/FeatureLockBanner";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_BLACKLIST } from "@/lib/feature-flags";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 interface BlacklistedUser {
   id: string;
@@ -64,6 +65,10 @@ const BlacklistPage: FC = () => {
 
   const { locked: polledLock } = useFeatureLock(FEATURE_BLACKLIST, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Blacklist management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // This page is a long-lived list rather than a form the user navigates away
@@ -172,17 +177,7 @@ const BlacklistPage: FC = () => {
       setSelectedUser(null);
       setUserModalOpen(false);
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ?? "Blacklist management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        toast.error(apiError ?? "Failed to blacklist user. Please try again.");
-      }
+      handleApiError(error, "Failed to blacklist user. Please try again.");
       console.error("Failed to blacklist user:", error);
     }
   };
@@ -203,17 +198,7 @@ const BlacklistPage: FC = () => {
       setSelectedRoleId("");
       setRoleModalOpen(false);
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ?? "Blacklist management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        toast.error(apiError ?? "Failed to blacklist role. Please try again.");
-      }
+      handleApiError(error, "Failed to blacklist role. Please try again.");
       console.error("Failed to blacklist role:", error);
     }
   };
@@ -228,17 +213,7 @@ const BlacklistPage: FC = () => {
         prev ? { ...prev, users: prev.users.filter((u) => u.id !== user.id) } : prev,
       );
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ?? "Blacklist management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        toast.error(apiError ?? "Failed to remove user from the blacklist. Please try again.");
-      }
+      handleApiError(error, "Failed to remove user from the blacklist. Please try again.");
       console.error("Failed to remove user from blacklist:", error);
     }
   };
@@ -254,17 +229,7 @@ const BlacklistPage: FC = () => {
         prev ? { ...prev, roles: prev.roles.filter((id) => id !== roleId) } : prev,
       );
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ?? "Blacklist management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        toast.error(apiError ?? "Failed to remove role from the blacklist. Please try again.");
-      }
+      handleApiError(error, "Failed to remove role from the blacklist. Please try again.");
       console.error("Failed to remove role from blacklist:", error);
     }
   };

--- a/frontend/src/pages/manage/forms/_index.tsx
+++ b/frontend/src/pages/manage/forms/_index.tsx
@@ -25,13 +25,7 @@ import TableSkeleton from "@/components/skeletons/TableSkeleton";
 import FeatureLockBanner from "@/components/FeatureLockBanner";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_FORMS } from "@/lib/feature-flags";
-
-/** Extracts the status and API-supplied message from an Axios error, for the 503 lock check. */
-function readApiError(error: unknown): { status?: number; message?: string } {
-  const status = (error as { response?: { status?: number } })?.response?.status;
-  const message = (error as { response?: { data?: { error?: string } } })?.response?.data?.error;
-  return { status, message };
-}
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const FormsPage: FC = () => {
   let { guildId } = useParams();
@@ -50,6 +44,10 @@ const FormsPage: FC = () => {
   const [gallerySubmitForm, setGallerySubmitForm] = useState<Form | null>(null);
   const { locked: polledLock } = useFeatureLock(FEATURE_FORMS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Form management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // This page is a long-lived list rather than a form the user navigates away
@@ -114,17 +112,7 @@ const FormsPage: FC = () => {
       setForms((prev) => prev.filter((f) => f.form_id !== deleteModal.id));
       toast.success("Form deleted successfully");
     } catch (error) {
-      const { status, message } = readApiError(error);
-      if (status === 503) {
-        toast.warning(
-          message ?? "Form management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-        // status, not just 503, so every other failure needs its own here.
-        toast.error(message ?? "Failed to delete form. Please try again.");
-      }
+      handleApiError(error, "Failed to delete form. Please try again.");
       console.error("Failed to delete:", error);
     }
 
@@ -182,17 +170,7 @@ const FormsPage: FC = () => {
       toast.success("Form cloned");
       navigate(`/manage/${guildId}/forms/edit/${newForm.form_id}`);
     } catch (error) {
-      const { status, message } = readApiError(error);
-      if (status === 503) {
-        toast.warning(
-          message ?? "Form management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-        // status, not just 503, so every other failure needs its own here.
-        toast.error(message ?? "Failed to clone form. Please try again.");
-      }
+      handleApiError(error, "Failed to clone form. Please try again.");
       console.error("Failed to clone form:", error);
     } finally {
       setCloningFormId(null);

--- a/frontend/src/pages/manage/forms/create.tsx
+++ b/frontend/src/pages/manage/forms/create.tsx
@@ -12,6 +12,7 @@ import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_FORMS } from "@/lib/feature-flags";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const CreateFormPage: FC = () => {
   const navigate = useNavigate();
@@ -23,6 +24,10 @@ const CreateFormPage: FC = () => {
   const [isCreating, setIsCreating] = useState(false);
   const { locked: polledLock } = useFeatureLock(FEATURE_FORMS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Form management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // Announce the lock lifting mid-session (e.g. a flag re-enabled while this page
@@ -72,19 +77,7 @@ const CreateFormPage: FC = () => {
         navigate(`/manage/${guildId}/forms/edit/${response.data.form_id}`);
       }
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ?? "Form management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-        // status, not just 503, so every other failure needs its own here.
-        toast.error(apiError ?? "Failed to create form. Please try again.");
-      }
+      handleApiError(error, "Failed to create form. Please try again.");
       console.error("Failed to create form:", error);
     } finally {
       setIsCreating(false);

--- a/frontend/src/pages/manage/forms/edit.tsx
+++ b/frontend/src/pages/manage/forms/edit.tsx
@@ -14,17 +14,11 @@ import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_FORMS } from "@/lib/feature-flags";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus, faEdit, faFloppyDisk } from "@fortawesome/free-solid-svg-icons";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 interface ExtendedFormInput extends FormInput {
   is_new?: boolean;
   placeholder?: string;
-}
-
-/** Extracts the status and API-supplied message from an Axios error, for the 503 lock check. */
-function readApiError(error: unknown): { status?: number; message?: string } {
-  const status = (error as { response?: { status?: number } })?.response?.status;
-  const message = (error as { response?: { data?: { error?: string } } })?.response?.data?.error;
-  return { status, message };
 }
 
 const EditFormPage: FC = () => {
@@ -42,6 +36,10 @@ const EditFormPage: FC = () => {
   const [inputValidationErrors, setInputValidationErrors] = useState<Record<number, boolean>>({});
   const { locked: polledLock } = useFeatureLock(FEATURE_FORMS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Form management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // This page is a long-lived editor rather than a form the user navigates away
@@ -113,17 +111,7 @@ const EditFormPage: FC = () => {
       setEditingTitle(false);
       toast.success("Form title updated");
     } catch (error) {
-      const { status, message } = readApiError(error);
-      if (status === 503) {
-        toast.warning(
-          message ?? "Form management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-        // status, not just 503, so every other failure needs its own here.
-        toast.error(message ?? "Failed to update form title. Please try again.");
-      }
+      handleApiError(error, "Failed to update form title. Please try again.");
       console.error("Failed to update form title:", error);
     }
   };
@@ -255,17 +243,7 @@ const EditFormPage: FC = () => {
       toast.success("Form updated successfully");
       navigate(`/manage/${guildId}/forms`);
     } catch (error) {
-      const { status, message } = readApiError(error);
-      if (status === 503) {
-        toast.warning(
-          message ?? "Form management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-        // status, not just 503, so every other failure needs its own here.
-        toast.error(message ?? "Failed to save form fields. Please try again.");
-      }
+      handleApiError(error, "Failed to save form fields. Please try again.");
       console.error("Failed to save inputs:", error);
     } finally {
       setIsSaving(false);
@@ -286,17 +264,7 @@ const EditFormPage: FC = () => {
       toast.success("Form deleted successfully");
       navigate(`/manage/${guildId}/forms`);
     } catch (error) {
-      const { status, message } = readApiError(error);
-      if (status === 503) {
-        toast.warning(
-          message ?? "Form management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-        // status, not just 503, so every other failure needs its own here.
-        toast.error(message ?? "Failed to delete form. Please try again.");
-      }
+      handleApiError(error, "Failed to delete form. Please try again.");
       console.error("Failed to delete form:", error);
     }
   };

--- a/frontend/src/pages/manage/integrations/_index.tsx
+++ b/frontend/src/pages/manage/integrations/_index.tsx
@@ -17,6 +17,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus, faServer, faEye, faCog, faTrash } from "@fortawesome/free-solid-svg-icons";
 import CardGridSkeleton from "@/components/skeletons/CardGridSkeleton";
 import Pagination from "@/components/Pagination";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 function generateProxyUrl(integration: Integration): string | null {
   if (!integration.image_url || !integration.proxy_token) return null;
@@ -190,6 +191,10 @@ const IntegrationsPage: FC = () => {
   } | null>(null);
   const { locked: polledLock } = useFeatureLock(FEATURE_INTEGRATIONS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Integration management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // This page is a long-lived list rather than a form the user navigates away
@@ -259,20 +264,7 @@ const IntegrationsPage: FC = () => {
         prev.map((i) => (i.id === removeModal.id ? { ...i, added: false } : i)),
       );
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ??
-            "Integration management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every status,
-        // not just 503, so every other failure needs its own here.
-        toast.error(apiError ?? "Failed to remove integration. Please try again.");
-      }
+      handleApiError(error, "Failed to remove integration. Please try again.");
       console.error("Failed to remove integration:", error);
     }
     setRemoveModal(null);

--- a/frontend/src/pages/manage/integrations/activate.tsx
+++ b/frontend/src/pages/manage/integrations/activate.tsx
@@ -11,6 +11,7 @@ import FeatureLockBanner from "@/components/FeatureLockBanner";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_INTEGRATIONS } from "@/lib/feature-flags";
 import type { Integration } from "@/types";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const ActivateIntegrationPage: FC = () => {
   let { guildId, integration: integrationId } = useParams();
@@ -24,6 +25,10 @@ const ActivateIntegrationPage: FC = () => {
   const [secretValues, setSecretValues] = useState<Record<string, string>>({});
   const { locked: polledLock } = useFeatureLock(FEATURE_INTEGRATIONS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Integration management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // Announce the lock lifting mid-session (e.g. a flag re-enabled while this page
@@ -73,20 +78,7 @@ const ActivateIntegrationPage: FC = () => {
       );
       navigate(`/manage/${guildId}/integrations?added=true`);
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ??
-            "Integration management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every status,
-        // not just 503, so every other failure needs its own here.
-        toast.error(apiError ?? "Failed to add integration. Please try again.");
-      }
+      handleApiError(error, "Failed to add integration. Please try again.");
       console.error("Failed to activate integration:", error);
     }
   };

--- a/frontend/src/pages/manage/integrations/configure.tsx
+++ b/frontend/src/pages/manage/integrations/configure.tsx
@@ -12,6 +12,7 @@ import FeatureLockBanner from "@/components/FeatureLockBanner";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_INTEGRATIONS } from "@/lib/feature-flags";
 import type { Integration } from "@/types";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const ConfigureIntegrationPage: FC = () => {
   let { guildId, integration: integrationId } = useParams();
@@ -76,20 +77,10 @@ const ConfigureIntegrationPage: FC = () => {
     (Object.keys(secretValues).length === integration.secrets.length &&
       Object.values(secretValues).every((v) => v.length > 0));
 
-  const handleApiError = (error: unknown, fallbackMessage: string) => {
-    const status = (error as { response?: { status?: number } })?.response?.status;
-    const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data?.error;
-    if (status === 503) {
-      toast.warning(
-        apiError ?? "Integration management is temporarily unavailable. Please try again shortly.",
-      );
-      setForcedLock(true);
-    } else {
-      // SKIP_ERROR_TOAST opts out of the interceptor's toast for every status,
-      // not just 503, so every other failure needs its own here.
-      toast.error(apiError ?? fallbackMessage);
-    }
-  };
+  const handleApiError = useApiErrorHandler(
+    "Integration management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
 
   const handleSave = async () => {
     try {

--- a/frontend/src/pages/manage/integrations/create.tsx
+++ b/frontend/src/pages/manage/integrations/create.tsx
@@ -20,6 +20,7 @@ import type {
 } from "@/types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 function buildExampleJson(placeholders: IntegrationPlaceholder[]): string {
   try {
@@ -68,6 +69,10 @@ const CreateIntegrationPage: FC = () => {
 
   const { locked: polledLock } = useFeatureLock(FEATURE_INTEGRATIONS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Integration management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // Announce the lock lifting mid-session (e.g. a flag re-enabled while this page
@@ -169,20 +174,7 @@ const CreateIntegrationPage: FC = () => {
       const res = await apiClient.integrations.create(payload, SKIP_ERROR_TOAST);
       navigate(`/manage/${guildId}/integrations/view/${res.data.id}?created=true`);
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ??
-            "Integration management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every status,
-        // not just 503, so every other failure needs its own here.
-        toast.error(apiError ?? "Failed to create integration. Please try again.");
-      }
+      handleApiError(error, "Failed to create integration. Please try again.");
       console.error("Failed to create integration:", error);
     }
   };

--- a/frontend/src/pages/manage/integrations/manage.tsx
+++ b/frontend/src/pages/manage/integrations/manage.tsx
@@ -21,6 +21,7 @@ import type {
 } from "@/types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 function buildExampleJson(placeholders: IntegrationPlaceholder[]): string {
   try {
@@ -180,20 +181,10 @@ const ManageIntegrationPage: FC = () => {
       prev ? { ...prev, headers: (prev.headers ?? []).filter((_, idx) => idx !== i) } : prev,
     );
 
-  const handleApiError = (error: unknown, fallbackMessage: string) => {
-    const status = (error as { response?: { status?: number } })?.response?.status;
-    const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data?.error;
-    if (status === 503) {
-      toast.warning(
-        apiError ?? "Integration management is temporarily unavailable. Please try again shortly.",
-      );
-      setForcedLock(true);
-    } else {
-      // SKIP_ERROR_TOAST opts out of the interceptor's toast for every status,
-      // not just 503, so every other failure needs its own here.
-      toast.error(apiError ?? fallbackMessage);
-    }
-  };
+  const handleApiError = useApiErrorHandler(
+    "Integration management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
 
   const handleSave = async () => {
     if (!data) return;

--- a/frontend/src/pages/manage/integrations/view.tsx
+++ b/frontend/src/pages/manage/integrations/view.tsx
@@ -12,6 +12,7 @@ import FeatureLockBanner from "@/components/FeatureLockBanner";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_INTEGRATIONS } from "@/lib/feature-flags";
 import type { Integration } from "@/types";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const ViewIntegrationPage: FC = () => {
   let { guildId, integration: integrationId } = useParams();
@@ -27,6 +28,10 @@ const ViewIntegrationPage: FC = () => {
   const [removeModal, setRemoveModal] = useState(false);
   const { locked: polledLock } = useFeatureLock(FEATURE_INTEGRATIONS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Integration management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // Announce the lock lifting mid-session (e.g. a flag re-enabled while this page
@@ -84,20 +89,7 @@ const ViewIntegrationPage: FC = () => {
       toast.success("Integration removed from server");
       navigate(`/manage/${guildId}/integrations`);
     } catch (error) {
-      const status = (error as { response?: { status?: number } })?.response?.status;
-      const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-        ?.error;
-      if (status === 503) {
-        toast.warning(
-          apiError ??
-            "Integration management is temporarily unavailable. Please try again shortly.",
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every status,
-        // not just 503, so every other failure needs its own here.
-        toast.error(apiError ?? "Failed to remove integration. Please try again.");
-      }
+      handleApiError(error, "Failed to remove integration. Please try again.");
       console.error("Failed to remove integration:", error);
     }
     setRemoveModal(false);

--- a/frontend/src/pages/manage/multipanels/create.tsx
+++ b/frontend/src/pages/manage/multipanels/create.tsx
@@ -30,6 +30,7 @@ import { PANEL_MESSAGE_INFO } from "@/constants/panelChannelInfo";
 import MultiPanelInfoModal from "@/components/modals/MultiPanelInfoModal";
 import { EMBED_LIMITS } from "@/constants/embedLimits";
 import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 type MultiPanelDraft = Omit<MultiPanelRequest, "channel_id"> & {
   channel_id?: MultiPanelRequest["channel_id"];
@@ -44,6 +45,10 @@ const MultiPanelsPage: FC = () => {
 
   const { locked: polledLock } = useFeatureLock(FEATURE_PANELS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Panel management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // Announce the lock lifting mid-session (e.g. a flag re-enabled while this page
@@ -525,20 +530,7 @@ const MultiPanelsPage: FC = () => {
             toast.success("Multi Panel Created");
             navigate(`/manage/${guildId}/panels`);
           } catch (error) {
-            const status = (error as { response?: { status?: number } })?.response?.status;
-            const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-              ?.error;
-            if (status === 503) {
-              toast.warning(
-                apiError ??
-                  "Panel management is temporarily unavailable. Please try again shortly.",
-              );
-              setForcedLock(true);
-            } else {
-              // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-              // status, not just 503, so every other failure needs its own here.
-              toast.error(apiError ?? "Failed to create multi panel. Please try again.");
-            }
+            handleApiError(error, "Failed to create multi panel. Please try again.");
             console.error("Failed to create multi panel:", error);
           }
         }}

--- a/frontend/src/pages/manage/multipanels/edit.tsx
+++ b/frontend/src/pages/manage/multipanels/edit.tsx
@@ -30,6 +30,7 @@ import { PANEL_MESSAGE_INFO } from "@/constants/panelChannelInfo";
 import MultiPanelInfoModal from "@/components/modals/MultiPanelInfoModal";
 import { EMBED_LIMITS } from "@/constants/embedLimits";
 import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const defaultEmbed = {
   author: {},
@@ -47,6 +48,10 @@ const MultiPanelsPage: FC = () => {
 
   const { locked: polledLock } = useFeatureLock(FEATURE_PANELS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Panel management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // Announce the lock lifting mid-session (e.g. a flag re-enabled while this page
@@ -511,20 +516,7 @@ const MultiPanelsPage: FC = () => {
             toast.success("Multi Panel Edited");
             navigate(`/manage/${guildId}/panels`);
           } catch (error) {
-            const status = (error as { response?: { status?: number } })?.response?.status;
-            const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-              ?.error;
-            if (status === 503) {
-              toast.warning(
-                apiError ??
-                  "Panel management is temporarily unavailable. Please try again shortly.",
-              );
-              setForcedLock(true);
-            } else {
-              // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-              // status, not just 503, so every other failure needs its own here.
-              toast.error(apiError ?? "Failed to save multi panel. Please try again.");
-            }
+            handleApiError(error, "Failed to save multi panel. Please try again.");
             console.error("Failed to edit multi panel:", error);
           }
         }}

--- a/frontend/src/pages/manage/panels/_index.tsx
+++ b/frontend/src/pages/manage/panels/_index.tsx
@@ -42,16 +42,10 @@ import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_PANELS } from "@/lib/feature-flags";
 import { useTableSort } from "@/hooks/useTableSort";
 import type { SortColumn } from "@/lib/table-sort";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 type PanelSortKey = "channel" | "title" | "status";
 type GallerySortKey = "name" | "category" | "status" | "imports";
-
-/** Extracts the status and API-supplied message from an Axios error, for the 503 lock check. */
-function readApiError(error: unknown): { status?: number; message?: string } {
-  const status = (error as { response?: { status?: number } })?.response?.status;
-  const message = (error as { response?: { data?: { error?: string } } })?.response?.data?.error;
-  return { status, message };
-}
 
 // Ranked by severity so the status column sorts by meaning, not by rendered label.
 function statusRank(panel: Panel): number {
@@ -133,6 +127,10 @@ const PanelsPage: FC = () => {
 
   const { locked: polledLock } = useFeatureLock(FEATURE_PANELS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Panel management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // This page is a long-lived list rather than a form the user navigates away
@@ -174,20 +172,10 @@ const PanelsPage: FC = () => {
         toast.success("Multi-panel deleted successfully");
       }
     } catch (error) {
-      const { status, message } = readApiError(error);
-      if (status === 503) {
-        toast.warning(
-          message ??
-            `${isPanel ? "Panel" : "Multi-panel"} management is temporarily unavailable. Please try again shortly.`,
-        );
-        setForcedLock(true);
-      } else {
-        // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-        // status, not just 503, so every other failure needs its own here.
-        toast.error(
-          message ?? `Failed to delete ${isPanel ? "panel" : "multi-panel"}. Please try again.`,
-        );
-      }
+      handleApiError(
+        error,
+        `Failed to delete ${isPanel ? "panel" : "multi-panel"}. Please try again.`,
+      );
       console.error("Failed to delete:", error);
     }
 
@@ -343,18 +331,10 @@ const PanelsPage: FC = () => {
                                     .resend(guildId, panel.panel_id.toString(), SKIP_ERROR_TOAST)
                                     .then(() => toast.success("Successfully re-sent panel"))
                                     .catch((error) => {
-                                      const { status, message } = readApiError(error);
-                                      if (status === 503) {
-                                        toast.warning(
-                                          message ??
-                                            "Panel management is temporarily unavailable. Please try again shortly.",
-                                        );
-                                        setForcedLock(true);
-                                      } else {
-                                        toast.error(
-                                          message ?? "Failed to re-send panel. Please try again.",
-                                        );
-                                      }
+                                      handleApiError(
+                                        error,
+                                        "Failed to re-send panel. Please try again.",
+                                      );
                                       console.error("Failed to re-send panel:", error);
                                     }),
                               },
@@ -460,19 +440,10 @@ const PanelsPage: FC = () => {
                                     .resend(guildId, panel.id.toString(), SKIP_ERROR_TOAST)
                                     .then(() => toast.success("Successfully re-sent multi panel"))
                                     .catch((error) => {
-                                      const { status, message } = readApiError(error);
-                                      if (status === 503) {
-                                        toast.warning(
-                                          message ??
-                                            "Panel management is temporarily unavailable. Please try again shortly.",
-                                        );
-                                        setForcedLock(true);
-                                      } else {
-                                        toast.error(
-                                          message ??
-                                            "Failed to re-send multi panel. Please try again.",
-                                        );
-                                      }
+                                      handleApiError(
+                                        error,
+                                        "Failed to re-send multi panel. Please try again.",
+                                      );
                                       console.error("Failed to re-send multi panel:", error);
                                     }),
                               },

--- a/frontend/src/pages/manage/panels/create.tsx
+++ b/frontend/src/pages/manage/panels/create.tsx
@@ -51,6 +51,7 @@ import { useMutationGuard } from "@/hooks/useMutationGuard";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { EMBED_LIMITS } from "@/constants/embedLimits";
 import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const PRESET_NAMING_SCHEMES = [
   "ticket-%id%",
@@ -171,6 +172,10 @@ const PanelsPage: FC = () => {
   const { isSubmitting, guard } = useMutationGuard();
   const { locked: polledLock } = useFeatureLock(FEATURE_PANELS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Panel management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // Announce the lock lifting mid-session (e.g. a flag re-enabled while this page
@@ -1236,20 +1241,7 @@ const PanelsPage: FC = () => {
               toast.success("Panel Created");
               navigate(`/manage/${guildId}/panels`);
             } catch (error) {
-              const status = (error as { response?: { status?: number } })?.response?.status;
-              const apiError = (error as { response?: { data?: { error?: string } } })?.response
-                ?.data?.error;
-              if (status === 503) {
-                toast.warning(
-                  apiError ??
-                    "Panel management is temporarily unavailable. Please try again shortly.",
-                );
-                setForcedLock(true);
-              } else {
-                // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-                // status, not just 503, so every other failure needs its own here.
-                toast.error(apiError ?? "Failed to create panel. Please try again.");
-              }
+              handleApiError(error, "Failed to create panel. Please try again.");
               console.error("Failed to create panel:", error);
             }
           });

--- a/frontend/src/pages/manage/panels/edit.tsx
+++ b/frontend/src/pages/manage/panels/edit.tsx
@@ -49,6 +49,7 @@ import TicketModeInfoModal from "@/components/modals/TicketModeInfoModal";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { EMBED_LIMITS } from "@/constants/embedLimits";
 import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const PRESET_NAMING_SCHEMES = [
   "ticket-%id%",
@@ -100,6 +101,10 @@ const EditPanelsPage: FC = () => {
   const [ticketModeInfoOpen, setTicketModeInfoOpen] = useState(false);
   const { locked: polledLock } = useFeatureLock(FEATURE_PANELS, guildId);
   const [forcedLock, setForcedLock] = useState(false);
+  const handleApiError = useApiErrorHandler(
+    "Panel management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
   const isLocked = forcedLock || polledLock === true;
 
   // Announce the lock lifting mid-session (e.g. a flag re-enabled while this page
@@ -1177,20 +1182,7 @@ const EditPanelsPage: FC = () => {
             toast.success("Panel Edited");
             navigate(`/manage/${guildId}/panels`);
           } catch (error) {
-            const status = (error as { response?: { status?: number } })?.response?.status;
-            const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data
-              ?.error;
-            if (status === 503) {
-              toast.warning(
-                apiError ??
-                  "Panel management is temporarily unavailable. Please try again shortly.",
-              );
-              setForcedLock(true);
-            } else {
-              // SKIP_ERROR_TOAST opts out of the interceptor's toast for every
-              // status, not just 503, so every other failure needs its own here.
-              toast.error(apiError ?? "Failed to save panel. Please try again.");
-            }
+            handleApiError(error, "Failed to save panel. Please try again.");
             console.error("Failed to edit panel:", error);
           }
         }}

--- a/frontend/src/pages/manage/tags/_index.tsx
+++ b/frontend/src/pages/manage/tags/_index.tsx
@@ -31,6 +31,7 @@ import GallerySubmitModal from "@/components/modals/GallerySubmitModal";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_TAGS } from "@/lib/feature-flags";
 import type { Tag } from "@/types";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const TAG_SORT_COLUMNS: Record<"id" | "type", SortColumn<Tag>> = {
   id: { value: (t) => t.id, defaultDir: "asc" },
@@ -88,20 +89,10 @@ const TagsPage: FC = () => {
     }
   }, [guildId, selectGuild, selectedGuild]);
 
-  // SKIP_ERROR_TOAST opts out of the interceptor's toast for every status, not
-  // just 503, so every other failure needs its own toast here.
-  const handleLockableError = (error: unknown, fallbackMessage: string) => {
-    const status = (error as { response?: { status?: number } })?.response?.status;
-    const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data?.error;
-    if (status === 503) {
-      toast.warning(
-        apiError ?? "Tag management is temporarily unavailable. Please try again shortly.",
-      );
-      setForcedLock(true);
-    } else {
-      toast.error(apiError ?? fallbackMessage);
-    }
-  };
+  const handleLockableError = useApiErrorHandler(
+    "Tag management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
 
   const handleSave = async (tag: Tag, originalId?: string) => {
     try {

--- a/frontend/src/pages/manage/teams/_index.tsx
+++ b/frontend/src/pages/manage/teams/_index.tsx
@@ -20,6 +20,7 @@ import EmptyState from "@/components/EmptyState";
 import Table from "@/components/Table";
 import TableSkeleton from "@/components/skeletons/TableSkeleton";
 import type { Team, GuildRole } from "@/types";
+import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const USER_TYPE = 0;
 const ROLE_TYPE = 1;
@@ -96,23 +97,11 @@ const TeamsPage: FC = () => {
     previousLockRef.current = isLocked;
   }, [isLocked]);
 
-  // Stable identity: only closes over toast/setForcedLock, both stable, so it is
-  // safe to depend on from other useCallbacks (e.g. flushPendingPermissionsSave)
-  // without their identity churning on every render.
-  const handleTeamMutationError = useCallback((error: unknown, fallbackMessage: string) => {
-    const status = (error as { response?: { status?: number } })?.response?.status;
-    const apiError = (error as { response?: { data?: { error?: string } } })?.response?.data?.error;
-    if (status === 503) {
-      toast.warning(
-        apiError ?? "Team management is temporarily unavailable. Please try again shortly.",
-      );
-      setForcedLock(true);
-    } else {
-      // SKIP_ERROR_TOAST opts out of the interceptor's toast for every status, not
-      // just 503, so every other failure needs its own here.
-      toast.error(apiError ?? fallbackMessage);
-    }
-  }, []);
+  // Stable identity: flushPendingPermissionsSave lists this in its dep array.
+  const handleTeamMutationError = useApiErrorHandler(
+    "Team management is temporarily unavailable. Please try again shortly.",
+    setForcedLock,
+  );
 
   const [searchParams, setSearchParams] = useSearchParams();
 

--- a/frontend/src/stores/errorModal.ts
+++ b/frontend/src/stores/errorModal.ts
@@ -4,6 +4,7 @@ export interface ErrorDetails {
   status?: number;
   message: string;
   apiError?: string;
+  internalError?: string;
   requestUrl?: string;
   requestMethod?: string;
 }


### PR DESCRIPTION
## Description
Failed mutations on pages that handle their own errors showed a bare toast with no **Details** button, so `ErrorDetailModal` was unreachable. Reported for panel saves ("Failed to update panel"), but the same pattern was copy-pasted into **30 catch blocks across 18 files**.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Hit a simple panel error while updating a panel, this should now give you the error details

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
