### PR TITLE
Fix: Remove the Overflow Category if Overflow is disabled

### DIFF
--- a/backend/app/http/endpoints/api/panel/panelcreate.go
+++ b/backend/app/http/endpoints/api/panel/panelcreate.go
@@ -161,6 +161,10 @@ func CreatePanel(c *gin.Context) {
 		return
 	}
 
+	if !data.OverflowEnabled {
+		data.OverflowCategoryId = nil
+	}
+
 	// Do custom validation
 	validationContext := PanelValidationContext{
 		Data:       data,

--- a/backend/app/http/endpoints/api/panel/panelupdate.go
+++ b/backend/app/http/endpoints/api/panel/panelupdate.go
@@ -103,6 +103,10 @@ func UpdatePanel(c *gin.Context) {
 		return
 	}
 
+	if !data.OverflowEnabled {
+		data.OverflowCategoryId = nil
+	}
+
 	// Do custom validation
 	validationContext := PanelValidationContext{
 		Data:       data,

--- a/frontend/src/lib/panel-payload.ts
+++ b/frontend/src/lib/panel-payload.ts
@@ -77,6 +77,10 @@ export function preparePanelForApi(panel: Panel): Partial<Panel> {
 
   payload.emote = buildPanelEmote(panel) as Panel["emote"];
 
+  if (!panel.overflow_enabled) {
+    delete payload.overflow_category_id;
+  }
+
   if (panel.welcome_message) {
     payload.welcome_message = {
       ...panel.welcome_message,


### PR DESCRIPTION
## Description
Remove the Overflow Category if Overflow is disabled

This cause servers to error if they had select a category that does not exist, while having Overflow disabled

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Enable Overflow
Select a category
Disable Overflow
Save
Enable Overflow again and the selected category from before should be removed

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
