### PR TITLE
Fix: Make table filters and sorting reachable on mobile

### DIFF
--- a/frontend/src/components/HiddenColumnControls.tsx
+++ b/frontend/src/components/HiddenColumnControls.tsx
@@ -1,0 +1,121 @@
+import type { ReactNode } from "react";
+import Collapsible from "@/components/Collapsible";
+import { SortTrigger } from "@/components/SortableHeaderCell";
+import {
+  fallbackClass,
+  widestFallbackClass,
+  type FallbackClass,
+  type ResponsiveColumn,
+} from "@/lib/table-columns";
+import type { SortState } from "@/hooks/useTableSort";
+
+interface HiddenColumnControlsProps<K extends string, S extends string> {
+  columns: readonly ResponsiveColumn<K, S>[];
+  selectedColumns: readonly string[];
+  sort?: SortState<S>;
+  renderFilter?: (column: ResponsiveColumn<K, S>) => ReactNode;
+  activeFilterCount?: number;
+  title?: string;
+  defaultOpen?: boolean;
+}
+
+const CHIP_CLASS = "rounded-full border-2 px-2.5 py-1 text-xs font-medium whitespace-nowrap";
+
+/**
+ * Surfaces the filter and sort controls whose table header is out of reach. Each entry carries its
+ * own visibility class, so a header copy and this copy are never both in the accessibility tree.
+ */
+export default function HiddenColumnControls<K extends string, S extends string>({
+  columns,
+  selectedColumns,
+  sort,
+  renderFilter,
+  activeFilterCount = 0,
+  title = "Filters & sorting",
+  defaultOpen = false,
+}: HiddenColumnControlsProps<K, S>) {
+  const visibilityFor = (column: ResponsiveColumn<K, S>) =>
+    fallbackClass(column.breakpoint, selectedColumns.includes(column.key));
+
+  const filterEntries: { key: K; className: FallbackClass; body: ReactNode }[] = [];
+  if (renderFilter) {
+    for (const column of columns) {
+      const className = visibilityFor(column);
+      if (className === "hidden") continue;
+      const body = renderFilter(column);
+      if (body == null) continue;
+      filterEntries.push({ key: column.key, className, body });
+    }
+  }
+
+  const sortEntries: { key: S; label: string; className: FallbackClass }[] = [];
+  if (sort) {
+    for (const column of columns) {
+      if (!column.sortKey) continue;
+      const reachable = selectedColumns.includes(column.key) || column.sortKey !== sort.sortKey;
+      const className = fallbackClass(column.breakpoint, reachable);
+      if (className === "hidden") continue;
+      sortEntries.push({ key: column.sortKey, label: column.label, className });
+    }
+  }
+
+  const sortSectionClass = widestFallbackClass(sortEntries.map((entry) => entry.className));
+  const panelClass = widestFallbackClass([
+    ...filterEntries.map((entry) => entry.className),
+    sortSectionClass,
+  ]);
+
+  if (panelClass === "hidden") return null;
+
+  const activeSortColumn = sort
+    ? columns.find((column) => column.sortKey === sort.sortKey)
+    : undefined;
+
+  const subtitle =
+    [
+      activeSortColumn && sort
+        ? `sorted by ${activeSortColumn.label} ${sort.sortDir === "asc" ? "ascending" : "descending"}`
+        : null,
+      activeFilterCount > 0
+        ? `${activeFilterCount} filter${activeFilterCount === 1 ? "" : "s"} active`
+        : null,
+    ]
+      .filter(Boolean)
+      .join(" · ") || undefined;
+
+  return (
+    <div className={panelClass}>
+      <Collapsible title={title} subtitle={subtitle} defaultOpen={defaultOpen}>
+        <div className="flex flex-col gap-4">
+          {sort && sortEntries.length > 0 && (
+            <div className={sortSectionClass}>
+              <span className="mb-2 block text-sm font-medium text-white">Sort by</span>
+              <div className="flex flex-wrap gap-1.5">
+                {sortEntries.map((entry) => (
+                  <span key={entry.key} className={entry.className}>
+                    <SortTrigger
+                      sort={sort}
+                      sortKey={entry.key}
+                      label={entry.label}
+                      inheritText
+                      className={`${CHIP_CLASS} ${
+                        sort.sortKey === entry.key
+                          ? "border-blue-500 bg-blue-500/20"
+                          : "border-transparent bg-gray-600/50 opacity-60 hover:opacity-100"
+                      }`}
+                    />
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+          {filterEntries.map((entry) => (
+            <div key={entry.key} className={entry.className}>
+              {entry.body}
+            </div>
+          ))}
+        </div>
+      </Collapsible>
+    </div>
+  );
+}

--- a/frontend/src/lib/table-columns.ts
+++ b/frontend/src/lib/table-columns.ts
@@ -1,0 +1,49 @@
+export type ColumnBreakpoint = "sm" | "md" | "lg";
+
+export interface ResponsiveColumn<K extends string = string, S extends string = string> {
+  key: K;
+  label: string;
+  breakpoint?: ColumnBreakpoint;
+  sortKey?: S;
+}
+
+// Ordered never-visible to always-visible; `widestFallbackClass` ranks by index.
+const FALLBACK_ORDER = ["hidden", "sm:hidden", "md:hidden", "lg:hidden", ""] as const;
+
+export type FallbackClass = (typeof FALLBACK_ORDER)[number];
+
+// Written out in full: Tailwind scans raw source text, so an interpolated breakpoint emits nothing.
+const CELL_CLASS: Record<ColumnBreakpoint, string> = {
+  sm: "hidden sm:table-cell",
+  md: "hidden md:table-cell",
+  lg: "hidden lg:table-cell",
+};
+
+const FALLBACK_BY_BREAKPOINT: Record<ColumnBreakpoint, FallbackClass> = {
+  sm: "sm:hidden",
+  md: "md:hidden",
+  lg: "lg:hidden",
+};
+
+export function cellClass(breakpoint?: ColumnBreakpoint): string {
+  return breakpoint ? CELL_CLASS[breakpoint] : "";
+}
+
+/** Inverse of `cellClass`. `rendered: false` = column switched off, so its stand-in shows at every
+ * width. "hidden" = header always reachable; callers skip those rather than mount a duplicate. */
+export function fallbackClass(
+  breakpoint: ColumnBreakpoint | undefined,
+  rendered: boolean,
+): FallbackClass {
+  if (!rendered) return "";
+  return breakpoint ? FALLBACK_BY_BREAKPOINT[breakpoint] : "hidden";
+}
+
+/** The class a wrapper needs so it is present whenever at least one of its children is. */
+export function widestFallbackClass(classes: readonly FallbackClass[]): FallbackClass {
+  let widest: FallbackClass = "hidden";
+  for (const candidate of classes) {
+    if (FALLBACK_ORDER.indexOf(candidate) > FALLBACK_ORDER.indexOf(widest)) widest = candidate;
+  }
+  return widest;
+}

--- a/frontend/src/pages/manage/tickets/_index.tsx
+++ b/frontend/src/pages/manage/tickets/_index.tsx
@@ -22,11 +22,13 @@ import {
   faXmark,
 } from "@fortawesome/free-solid-svg-icons";
 import ColumnSelectorButton from "@/components/ColumnSelectorButton";
+import HiddenColumnControls from "@/components/HiddenColumnControls";
 import Button from "@/components/Button";
 import Table from "@/components/Table";
 import SortableHeaderCell from "@/components/SortableHeaderCell";
 import { useTableSort } from "@/hooks/useTableSort";
 import { toTime, type SortColumn, type SortDir } from "@/lib/table-sort";
+import { cellClass, type ResponsiveColumn } from "@/lib/table-columns";
 import TextInput from "@/components/TextInput";
 import NumberInput from "@/components/NumberInput";
 import Select from "@/components/Select";
@@ -112,38 +114,30 @@ type ColumnKey =
 
 type TicketSortKey = Exclude<ColumnKey, "labels"> | "unclaimed";
 
-interface ColumnDef {
-  key: ColumnKey;
-  label: string;
-  responsiveClass: string;
-  sortKey?: TicketSortKey;
-}
+type ColumnDef = ResponsiveColumn<ColumnKey, TicketSortKey>;
 
 const ALL_COLUMNS: ColumnDef[] = [
-  { key: "id", label: "ID", responsiveClass: "", sortKey: "id" },
-  { key: "panel", label: "Panel", responsiveClass: "hidden sm:table-cell", sortKey: "panel" },
-  { key: "user", label: "User", responsiveClass: "hidden sm:table-cell", sortKey: "user" },
-  { key: "opened", label: "Opened", responsiveClass: "hidden lg:table-cell", sortKey: "opened" },
-  {
-    key: "claimed_by",
-    label: "Claimed By",
-    responsiveClass: "hidden md:table-cell",
-    sortKey: "claimed_by",
-  },
-  {
-    key: "last_message",
-    label: "Last Message",
-    responsiveClass: "hidden lg:table-cell",
-    sortKey: "last_message",
-  },
+  { key: "id", label: "ID", sortKey: "id" },
+  { key: "panel", label: "Panel", breakpoint: "sm", sortKey: "panel" },
+  { key: "user", label: "User", breakpoint: "sm", sortKey: "user" },
+  { key: "opened", label: "Opened", breakpoint: "lg", sortKey: "opened" },
+  { key: "claimed_by", label: "Claimed By", breakpoint: "md", sortKey: "claimed_by" },
+  { key: "last_message", label: "Last Message", breakpoint: "lg", sortKey: "last_message" },
   {
     key: "awaiting_response",
     label: "Awaiting Response",
-    responsiveClass: "hidden lg:table-cell",
+    breakpoint: "lg",
     sortKey: "awaiting_response",
   },
-  { key: "labels", label: "Labels", responsiveClass: "hidden md:table-cell" },
+  { key: "labels", label: "Labels", breakpoint: "md" },
 ];
+
+const COLUMN_BY_KEY = Object.fromEntries(ALL_COLUMNS.map((col) => [col.key, col])) as Record<
+  ColumnKey,
+  ColumnDef
+>;
+
+const cellClassFor = (key: ColumnKey) => cellClass(COLUMN_BY_KEY[key].breakpoint);
 
 // `?sort=id_asc` predates the sort/dir split; map it once so existing links keep working.
 const LEGACY_SORT: Record<string, { key: TicketSortKey; dir: SortDir }> = {
@@ -696,13 +690,6 @@ const TicketsPage: FC = () => {
     [selectedColumns],
   );
 
-  // Responsive classes hide columns independently of the selector, so never clear the sort here.
-  const hiddenSortLabel = useMemo(() => {
-    if (sort.sortKey === "unclaimed") return null;
-    if (visibleColumns.some((col) => col.sortKey === sort.sortKey)) return null;
-    return ALL_COLUMNS.find((col) => col.sortKey === sort.sortKey)?.label ?? null;
-  }, [sort.sortKey, visibleColumns]);
-
   const toggleColumn = (key: ColumnKey) => {
     if (selectedColumns.includes(key)) {
       if (selectedColumns.length <= 1) return;
@@ -830,13 +817,15 @@ const TicketsPage: FC = () => {
         </div>
       </div>
 
+      <HiddenColumnControls
+        columns={ALL_COLUMNS}
+        selectedColumns={selectedColumns}
+        sort={sort}
+        title="Sorting"
+      />
+
       {/* Column selector (hidden on mobile where responsive classes handle visibility) */}
       <div className="hidden sm:flex justify-end items-center gap-3 mb-3">
-        {hiddenSortLabel && (
-          <span className="text-sm text-gray-400">
-            Sorted by {hiddenSortLabel} {sort.sortDir === "asc" ? "↑" : "↓"}
-          </span>
-        )}
         <ColumnSelectorButton
           columns={ALL_COLUMNS}
           isOpen={showColumnSelector}
@@ -871,12 +860,12 @@ const TicketsPage: FC = () => {
                   sort={sort}
                   sortKey={col.sortKey}
                   label={col.label}
-                  className={col.responsiveClass}
+                  className={cellClass(col.breakpoint)}
                 />
               ) : (
                 <Table.HeaderCell
                   key={col.key}
-                  className={`px-3 sm:px-6 py-3 ${col.responsiveClass}`}
+                  className={`px-3 sm:px-6 py-3 ${cellClass(col.breakpoint)}`}
                 >
                   {col.label}
                 </Table.HeaderCell>
@@ -893,7 +882,7 @@ const TicketsPage: FC = () => {
                   <Skeleton width={16} height={16} />
                 </Table.Cell>
                 {visibleColumns.map((col) => (
-                  <Table.Cell key={col.key} className="px-6 py-4">
+                  <Table.Cell key={col.key} className={`px-6 py-4 ${cellClass(col.breakpoint)}`}>
                     <Skeleton height={16} />
                   </Table.Cell>
                 ))}
@@ -935,22 +924,22 @@ const TicketsPage: FC = () => {
                     </Table.RowHeaderCell>
                   )}
                   {selectedColumns.includes("panel") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden sm:table-cell">
+                    <Table.Cell className={`px-3 sm:px-6 py-4 ${cellClassFor("panel")}`}>
                       {getPanelTitle(ticket.panel_id)}
                     </Table.Cell>
                   )}
                   {selectedColumns.includes("user") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden sm:table-cell">
+                    <Table.Cell className={`px-3 sm:px-6 py-4 ${cellClassFor("user")}`}>
                       {getDisplayName(ticket.user_id)}
                     </Table.Cell>
                   )}
                   {selectedColumns.includes("opened") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden lg:table-cell">
+                    <Table.Cell className={`px-3 sm:px-6 py-4 ${cellClassFor("opened")}`}>
                       {ticket.opened_at ? getRelativeTime(new Date(ticket.opened_at)) : "Unknown"}
                     </Table.Cell>
                   )}
                   {selectedColumns.includes("claimed_by") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden md:table-cell">
+                    <Table.Cell className={`px-3 sm:px-6 py-4 ${cellClassFor("claimed_by")}`}>
                       {ticket.claimed_by ? (
                         getDisplayName(ticket.claimed_by)
                       ) : (
@@ -959,14 +948,16 @@ const TicketsPage: FC = () => {
                     </Table.Cell>
                   )}
                   {selectedColumns.includes("last_message") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden lg:table-cell">
+                    <Table.Cell className={`px-3 sm:px-6 py-4 ${cellClassFor("last_message")}`}>
                       {ticket.last_response_time
                         ? getRelativeTime(new Date(ticket.last_response_time))
                         : "Never"}
                     </Table.Cell>
                   )}
                   {selectedColumns.includes("awaiting_response") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden lg:table-cell">
+                    <Table.Cell
+                      className={`px-3 sm:px-6 py-4 ${cellClassFor("awaiting_response")}`}
+                    >
                       {ticket.last_response_is_staff === false ? (
                         <span className="font-bold">Yes</span>
                       ) : (
@@ -975,7 +966,7 @@ const TicketsPage: FC = () => {
                     </Table.Cell>
                   )}
                   {selectedColumns.includes("labels") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden md:table-cell">
+                    <Table.Cell className={`px-3 sm:px-6 py-4 ${cellClassFor("labels")}`}>
                       <div className="flex flex-wrap gap-1 items-center">
                         {assignedLabels.map((label) => (
                           <LabelBadge

--- a/frontend/src/pages/manage/transcripts/_index.tsx
+++ b/frontend/src/pages/manage/transcripts/_index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type FC } from "react";
+import { useCallback, useEffect, useMemo, useState, type FC, type ReactNode } from "react";
 import { apiClient } from "@/lib/api";
 import { Link, useParams, useSearchParams } from "react-router";
 import { getGuildById } from "@/stores/auth";
@@ -18,7 +18,9 @@ import Button from "@/components/Button";
 import Table from "@/components/Table";
 import { SortTrigger, ariaSortFor } from "@/components/SortableHeaderCell";
 import ColumnFilter from "@/components/ColumnFilter";
+import HiddenColumnControls from "@/components/HiddenColumnControls";
 import { useSortState, type SortableColumns } from "@/hooks/useTableSort";
+import { cellClass, type ResponsiveColumn } from "@/lib/table-columns";
 import Pagination from "@/components/Pagination";
 import TextInput from "@/components/TextInput";
 import Textarea from "@/components/Textarea";
@@ -55,25 +57,22 @@ const RATING_OPTIONS = [
   { key: "5", label: "5 ⭐" },
 ];
 
-interface ColumnDef {
-  key: ColumnKey;
-  label: string;
-  responsiveClass: string;
-  sortKey?: SortKey;
-}
+type ColumnDef = ResponsiveColumn<ColumnKey, SortKey>;
 
 const ALL_COLUMNS: ColumnDef[] = [
-  { key: "id", label: "Ticket ID", responsiveClass: "", sortKey: "id" },
-  { key: "username", label: "Username", responsiveClass: "hidden sm:table-cell" },
-  { key: "rating", label: "Rating", responsiveClass: "hidden md:table-cell", sortKey: "rating" },
-  {
-    key: "close_reason",
-    label: "Close Reason",
-    responsiveClass: "hidden lg:table-cell",
-    sortKey: "close_reason",
-  },
-  { key: "labels", label: "Labels", responsiveClass: "hidden lg:table-cell" },
+  { key: "id", label: "Ticket ID", sortKey: "id" },
+  { key: "username", label: "Username", breakpoint: "sm" },
+  { key: "rating", label: "Rating", breakpoint: "md", sortKey: "rating" },
+  { key: "close_reason", label: "Close Reason", breakpoint: "lg", sortKey: "close_reason" },
+  { key: "labels", label: "Labels", breakpoint: "lg" },
 ];
+
+const COLUMN_BY_KEY = Object.fromEntries(ALL_COLUMNS.map((col) => [col.key, col])) as Record<
+  ColumnKey,
+  ColumnDef
+>;
+
+const cellClassFor = (key: ColumnKey) => cellClass(COLUMN_BY_KEY[key].breakpoint);
 
 const DEFAULT_COLUMNS: ColumnKey[] = ["id", "username", "rating", "close_reason", "labels"];
 
@@ -397,26 +396,24 @@ const TranscriptsPage: FC = () => {
       <SortTrigger sort={sort} sortKey={col.sortKey} label={col.label} inheritText />
     ) : undefined;
 
-  const renderHeader = (col: ColumnDef) => {
+  const columnFilter = (col: ColumnDef): { active: boolean; body: ReactNode } | null => {
     switch (col.key) {
       case "id":
-        return (
-          <ColumnFilter label="Ticket ID" active={!!ticketId} labelSlot={sortTrigger(col)}>
+        return {
+          active: !!ticketId,
+          body: (
             <TextInput
               label="Ticket ID"
               placeholder="Ticket ID"
               value={ticketId}
               onChange={setTicketId}
             />
-          </ColumnFilter>
-        );
+          ),
+        };
       case "username":
-        return (
-          <ColumnFilter
-            label="Username"
-            active={!!username || !!userId}
-            labelSlot={sortTrigger(col)}
-          >
+        return {
+          active: !!username || !!userId,
+          body: (
             <div className="space-y-2">
               <TextInput
                 label="Username"
@@ -431,81 +428,94 @@ const TranscriptsPage: FC = () => {
                 onChange={setUserId}
               />
             </div>
-          </ColumnFilter>
-        );
+          ),
+        };
       case "rating":
-        return (
-          <ColumnFilter label="Rating" active={rating !== "0"} labelSlot={sortTrigger(col)}>
-            <span className="mb-2 block text-sm font-medium text-white">Rating</span>
-            <div className="flex flex-wrap gap-1.5">
-              {RATING_OPTIONS.map((opt) => {
-                const isActive = rating === opt.key;
-                return (
-                  <Button
-                    key={opt.key}
-                    type="button"
-                    size="sm"
-                    onClick={() => setRating(opt.key)}
-                    aria-pressed={isActive}
-                    className={`rounded-full border-2 font-medium whitespace-nowrap cursor-pointer ${
-                      isActive
-                        ? "border-blue-500 bg-blue-500/20"
-                        : "border-transparent bg-gray-600/50 opacity-60 hover:opacity-100"
-                    }`}
-                  >
-                    {opt.label}
-                  </Button>
-                );
-              })}
-            </div>
-          </ColumnFilter>
-        );
+        return {
+          active: rating !== "0",
+          body: (
+            <>
+              <span className="mb-2 block text-sm font-medium text-white">Rating</span>
+              <div className="flex flex-wrap gap-1.5">
+                {RATING_OPTIONS.map((opt) => {
+                  const isActive = rating === opt.key;
+                  return (
+                    <Button
+                      key={opt.key}
+                      type="button"
+                      size="sm"
+                      onClick={() => setRating(opt.key)}
+                      aria-pressed={isActive}
+                      className={`rounded-full border-2 font-medium whitespace-nowrap cursor-pointer ${
+                        isActive
+                          ? "border-blue-500 bg-blue-500/20"
+                          : "border-transparent bg-gray-600/50 opacity-60 hover:opacity-100"
+                      }`}
+                    >
+                      {opt.label}
+                    </Button>
+                  );
+                })}
+              </div>
+            </>
+          ),
+        };
       case "close_reason":
-        return (
-          <ColumnFilter label="Close Reason" active={!!closeReason} labelSlot={sortTrigger(col)}>
+        return {
+          active: !!closeReason,
+          body: (
             <TextInput
               label="Close Reason"
               placeholder="Search close reason..."
               value={closeReason}
               onChange={setCloseReason}
             />
-          </ColumnFilter>
-        );
+          ),
+        };
       case "labels":
-        return labels.length === 0 ? (
-          <span>{col.label}</span>
-        ) : (
-          <ColumnFilter
-            label="Labels"
-            active={selectedLabelIds.length > 0}
-            labelSlot={sortTrigger(col)}
-          >
-            <div className="flex flex-wrap gap-1.5">
-              {labels.map((label) => {
-                const isActive = selectedLabelIds.includes(label.label_id);
-                const hex = intToColour(label.colour);
-                return (
-                  <Button
-                    key={label.label_id}
-                    type="button"
-                    className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium whitespace-nowrap transition-opacity cursor-pointer border-2 text-white"
-                    style={{
-                      backgroundColor: `color-mix(in srgb, ${hex} 20%, transparent)`,
-                      opacity: isActive ? 1 : 0.5,
-                      borderColor: isActive ? "#3b82f6" : "transparent",
-                    }}
-                    onClick={() => toggleLabelFilter(label.label_id)}
-                    aria-pressed={isActive}
-                  >
-                    <span className="w-2 h-2 rounded-full shrink-0" style={{ background: hex }} />
-                    {label.name}
-                  </Button>
-                );
-              })}
-            </div>
-          </ColumnFilter>
-        );
+        if (labels.length === 0) return null;
+        return {
+          active: selectedLabelIds.length > 0,
+          body: (
+            <>
+              <span className="mb-2 block text-sm font-medium text-white">Labels</span>
+              <div className="flex flex-wrap gap-1.5">
+                {labels.map((label) => {
+                  const isActive = selectedLabelIds.includes(label.label_id);
+                  const hex = intToColour(label.colour);
+                  return (
+                    <Button
+                      key={label.label_id}
+                      type="button"
+                      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium whitespace-nowrap transition-opacity cursor-pointer border-2 text-white"
+                      style={{
+                        backgroundColor: `color-mix(in srgb, ${hex} 20%, transparent)`,
+                        opacity: isActive ? 1 : 0.5,
+                        borderColor: isActive ? "#3b82f6" : "transparent",
+                      }}
+                      onClick={() => toggleLabelFilter(label.label_id)}
+                      aria-pressed={isActive}
+                    >
+                      <span className="w-2 h-2 rounded-full shrink-0" style={{ background: hex }} />
+                      {label.name}
+                    </Button>
+                  );
+                })}
+              </div>
+            </>
+          ),
+        };
     }
+  };
+
+  const renderHeader = (col: ColumnDef) => {
+    const filter = columnFilter(col);
+    if (!filter) return sortTrigger(col) ?? <span>{col.label}</span>;
+    return (
+      <ColumnFilter label={col.label} active={filter.active} labelSlot={sortTrigger(col)}>
+        {filter.body}
+      </ColumnFilter>
+    );
   };
   return (
     <MainLayout
@@ -558,6 +568,15 @@ const TranscriptsPage: FC = () => {
           </div>
         </div>
       </div>
+      <HiddenColumnControls
+        columns={ALL_COLUMNS}
+        selectedColumns={selectedColumns}
+        sort={sort}
+        renderFilter={(col) => columnFilter(col)?.body ?? null}
+        activeFilterCount={activeFilters.length}
+        title="Filters & sorting"
+      />
+
       {activeFilters.length > 0 && (
         <div className="flex flex-wrap items-center gap-2 mb-3">
           {activeFilters.map((f) => (
@@ -600,7 +619,7 @@ const TranscriptsPage: FC = () => {
               <Table.HeaderCell
                 key={col.key}
                 aria-sort={col.sortKey ? ariaSortFor(sort, col.sortKey) : undefined}
-                className={`px-3 sm:px-6 py-3 ${col.responsiveClass}`}
+                className={`px-3 sm:px-6 py-3 ${cellClass(col.breakpoint)}`}
               >
                 {renderHeader(col)}
               </Table.HeaderCell>
@@ -613,7 +632,7 @@ const TranscriptsPage: FC = () => {
             Array.from({ length: 6 }).map((_, i) => (
               <Table.Row key={`skeleton-${i}`} className="border-b bg-gray-800 border-gray-700">
                 {visibleColumns.map((col) => (
-                  <Table.Cell key={col.key} className="px-6 py-4">
+                  <Table.Cell key={col.key} className={`px-6 py-4 ${cellClass(col.breakpoint)}`}>
                     <Skeleton height={16} />
                   </Table.Cell>
                 ))}
@@ -668,22 +687,22 @@ const TranscriptsPage: FC = () => {
                     </Table.HeaderCell>
                   )}
                   {selectedColumns.includes("username") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden sm:table-cell">
+                    <Table.Cell className={`px-3 sm:px-6 py-4 ${cellClassFor("username")}`}>
                       {transcript.username}
                     </Table.Cell>
                   )}
                   {selectedColumns.includes("rating") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden md:table-cell">
+                    <Table.Cell className={`px-3 sm:px-6 py-4 ${cellClassFor("rating")}`}>
                       {transcript.rating ? `${transcript.rating} \u2B50` : "No rating"}
                     </Table.Cell>
                   )}
                   {selectedColumns.includes("close_reason") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden lg:table-cell">
+                    <Table.Cell className={`px-3 sm:px-6 py-4 ${cellClassFor("close_reason")}`}>
                       {transcript.close_reason ?? "No reason specified"}
                     </Table.Cell>
                   )}
                   {selectedColumns.includes("labels") && (
-                    <Table.Cell className="px-3 sm:px-6 py-4 hidden lg:table-cell">
+                    <Table.Cell className={`px-3 sm:px-6 py-4 ${cellClassFor("labels")}`}>
                       <div className="flex flex-wrap gap-1 items-center">
                         {transcript.labels?.map((label) => (
                           <LabelBadge


### PR DESCRIPTION
## Description
On the tickets and transcripts pages most filter and sort controls live inside `<th>` cells that carry `hidden sm/md/lg:table-cell`. On a narrow screen the header is gone and the control goes with it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
The tickets and transcripts pages should not include a section for filters that's not included in the table

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
