### PR TITLE
Fix: Gate the embed footer behind Premium

### DIFF
--- a/backend/app/http/endpoints/api/panel/footerpolicy.go
+++ b/backend/app/http/endpoints/api/panel/footerpolicy.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"context"
+
+	"github.com/TicketsBot-cloud/common/model"
+	"github.com/TicketsBot-cloud/common/premium"
+	"github.com/ticketsbot-cloud/dashboard/backend/botcontext"
+	"github.com/ticketsbot-cloud/dashboard/backend/rpc"
+)
+
+// No premium gets our branding, voting premium gets no footer at all, paid premium keeps its own.
+type footerPolicy struct {
+	ShowBranding bool
+	AllowCustom  bool
+}
+
+func footerPolicyForGuild(ctx context.Context, guildId uint64, botContext *botcontext.BotContext) (footerPolicy, error) {
+	tier, source, err := rpc.PremiumClient.GetTierByGuildIdWithSource(ctx, guildId, botContext.Token, botContext.RateLimiter)
+	if err != nil {
+		return footerPolicy{}, err
+	}
+
+	return footerPolicy{
+		ShowBranding: tier == premium.None,
+		AllowCustom:  tier > premium.None && source != model.EntitlementSourceVoting,
+	}, nil
+}

--- a/backend/app/http/endpoints/api/panel/multipanelcreate.go
+++ b/backend/app/http/endpoints/api/panel/multipanelcreate.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/TicketsBot-cloud/common/featureflags"
-	"github.com/TicketsBot-cloud/common/premium"
 	"github.com/TicketsBot-cloud/database"
 	"github.com/TicketsBot-cloud/gdl/objects/channel"
 	"github.com/TicketsBot-cloud/gdl/rest/request"
@@ -18,7 +17,6 @@ import (
 	"github.com/ticketsbot-cloud/dashboard/backend/app/http/validation"
 	"github.com/ticketsbot-cloud/dashboard/backend/botcontext"
 	dbclient "github.com/ticketsbot-cloud/dashboard/backend/database"
-	"github.com/ticketsbot-cloud/dashboard/backend/rpc"
 	"github.com/ticketsbot-cloud/dashboard/backend/rpc/cache"
 	"github.com/ticketsbot-cloud/dashboard/backend/utils"
 	"github.com/ticketsbot-cloud/dashboard/backend/utils/types"
@@ -48,9 +46,9 @@ type multiPanelCreateData struct {
 	Embed                 *types.CustomEmbed   `json:"embed" validate:"omitempty"`
 }
 
-func (d *multiPanelCreateData) IntoMessageData(isPremium bool) multiPanelMessageData {
+func (d *multiPanelCreateData) IntoMessageData(footer footerPolicy) multiPanelMessageData {
 	return multiPanelMessageData{
-		IsPremium:             isPremium,
+		Footer:                footer,
 		ChannelId:             d.ChannelId,
 		SelectMenu:            d.SelectMenu,
 		SelectMenuPlaceholder: d.SelectMenuPlaceholder,
@@ -125,8 +123,7 @@ func MultiPanelCreate(c *gin.Context) {
 		return
 	}
 
-	// get premium status
-	premiumTier, err := rpc.PremiumClient.GetTierByGuildId(c, guildId, true, botContext.Token, botContext.RateLimiter)
+	footer, err := footerPolicyForGuild(c, guildId, botContext)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to create multi-panel"))
 		return
@@ -144,7 +141,7 @@ func MultiPanelCreate(c *gin.Context) {
 		}
 	}
 
-	messageData := data.IntoMessageData(premiumTier > premium.None)
+	messageData := data.IntoMessageData(footer)
 	messageId, err := messageData.send(botContext, panelsWithCustom)
 	if err != nil {
 		var unwrapped request.RestError

--- a/backend/app/http/endpoints/api/panel/multipanelmessagedata.go
+++ b/backend/app/http/endpoints/api/panel/multipanelmessagedata.go
@@ -16,7 +16,7 @@ import (
 )
 
 type multiPanelMessageData struct {
-	IsPremium bool
+	Footer footerPolicy
 
 	ChannelId uint64
 
@@ -24,6 +24,14 @@ type multiPanelMessageData struct {
 	SelectMenuPlaceholder *string
 
 	Embed *embed.Embed
+}
+
+func (d *multiPanelMessageData) applyFooter() {
+	if d.Footer.ShowBranding {
+		d.Embed.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
+	} else if !d.Footer.AllowCustom {
+		d.Embed.Footer = nil
+	}
 }
 
 func multiPanelDiscordSubPanelError(action, detail string) string {
@@ -34,9 +42,9 @@ func multiPanelDiscordSubPanelError(action, detail string) string {
 	)
 }
 
-func multiPanelIntoMessageData(panel database.MultiPanel, isPremium bool) multiPanelMessageData {
+func multiPanelIntoMessageData(panel database.MultiPanel, footer footerPolicy) multiPanelMessageData {
 	return multiPanelMessageData{
-		IsPremium: isPremium,
+		Footer: footer,
 
 		ChannelId: panel.ChannelId,
 
@@ -85,9 +93,7 @@ func getEffectiveEmojiAnimated(panel database.Panel, customEmojiName *string, cu
 }
 
 func (d *multiPanelMessageData) send(ctx *botcontext.BotContext, panels []database.PanelWithCustomization) (uint64, error) {
-	if !d.IsPremium {
-		d.Embed.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
-	}
+	d.applyFooter()
 
 	var components []component.Component
 	if d.SelectMenu {
@@ -178,9 +184,7 @@ func (d *multiPanelMessageData) send(ctx *botcontext.BotContext, panels []databa
 }
 
 func (d *multiPanelMessageData) edit(ctx *botcontext.BotContext, messageId uint64, panels []database.PanelWithCustomization) error {
-	if !d.IsPremium {
-		d.Embed.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
-	}
+	d.applyFooter()
 
 	var components []component.Component
 	if d.SelectMenu {

--- a/backend/app/http/endpoints/api/panel/multipanelresend.go
+++ b/backend/app/http/endpoints/api/panel/multipanelresend.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/TicketsBot-cloud/common/featureflags"
-	"github.com/TicketsBot-cloud/common/premium"
 	"github.com/TicketsBot-cloud/database"
 	"github.com/TicketsBot-cloud/gdl/rest"
 	"github.com/TicketsBot-cloud/gdl/rest/request"
@@ -14,7 +13,6 @@ import (
 	"github.com/ticketsbot-cloud/dashboard/backend/app/http/audit"
 	"github.com/ticketsbot-cloud/dashboard/backend/botcontext"
 	dbclient "github.com/ticketsbot-cloud/dashboard/backend/database"
-	"github.com/ticketsbot-cloud/dashboard/backend/rpc"
 	"github.com/ticketsbot-cloud/dashboard/backend/utils"
 )
 
@@ -70,8 +68,7 @@ func MultiPanelResend(ctx *gin.Context) {
 		}
 	}
 
-	// get premium status
-	premiumTier, err := rpc.PremiumClient.GetTierByGuildId(ctx, guildId, true, botContext.Token, botContext.RateLimiter)
+	footer, err := footerPolicyForGuild(ctx, guildId, botContext)
 	if err != nil {
 		ctx.JSON(500, utils.ErrorStr("Unable to verify premium status. Please try again."))
 		return
@@ -84,7 +81,7 @@ func MultiPanelResend(ctx *gin.Context) {
 	}
 
 	// send new message
-	messageData := multiPanelIntoMessageData(multiPanel, premiumTier > premium.None)
+	messageData := multiPanelIntoMessageData(multiPanel, footer)
 	messageId, err := messageData.send(botContext, panels)
 	if err != nil {
 		var unwrapped request.RestError

--- a/backend/app/http/endpoints/api/panel/multipanelupdate.go
+++ b/backend/app/http/endpoints/api/panel/multipanelupdate.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 
 	"github.com/TicketsBot-cloud/common/featureflags"
-	"github.com/TicketsBot-cloud/common/premium"
 	"github.com/TicketsBot-cloud/database"
 	"github.com/TicketsBot-cloud/gdl/rest"
 	"github.com/TicketsBot-cloud/gdl/rest/request"
@@ -19,7 +18,6 @@ import (
 	"github.com/ticketsbot-cloud/dashboard/backend/app/http/validation"
 	"github.com/ticketsbot-cloud/dashboard/backend/botcontext"
 	dbclient "github.com/ticketsbot-cloud/dashboard/backend/database"
-	"github.com/ticketsbot-cloud/dashboard/backend/rpc"
 	"github.com/ticketsbot-cloud/dashboard/backend/utils"
 	"golang.org/x/sync/errgroup"
 )
@@ -138,8 +136,7 @@ func MultiPanelUpdate(c *gin.Context) {
 		return
 	}
 
-	// get premium status
-	premiumTier, err := rpc.PremiumClient.GetTierByGuildId(c, guildId, true, botContext.Token, botContext.RateLimiter)
+	footer, err := footerPolicyForGuild(c, guildId, botContext)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to update multi-panel"))
 		return
@@ -157,7 +154,7 @@ func MultiPanelUpdate(c *gin.Context) {
 		}
 	}
 
-	messageData := data.IntoMessageData(premiumTier > premium.None)
+	messageData := data.IntoMessageData(footer)
 	var messageId uint64
 
 	// Check if channel changed

--- a/backend/app/http/endpoints/api/panel/panelcreate.go
+++ b/backend/app/http/endpoints/api/panel/panelcreate.go
@@ -80,7 +80,7 @@ type panelBody struct {
 	AutoClose                 PanelAutoCloseBody                `json:"auto_close"`
 }
 
-func (p *panelBody) IntoPanelMessageData(customId string, isPremium bool) panelMessageData {
+func (p *panelBody) IntoPanelMessageData(customId string, showBranding bool) panelMessageData {
 	return panelMessageData{
 		ChannelId:      p.ChannelId,
 		Title:          p.Title,
@@ -93,7 +93,7 @@ func (p *panelBody) IntoPanelMessageData(customId string, isPremium bool) panelM
 		ButtonStyle:    p.ButtonStyle,
 		ButtonLabel:    p.ButtonLabel,
 		ButtonDisabled: p.Disabled,
-		IsPremium:      isPremium,
+		ShowBranding:   showBranding,
 	}
 }
 
@@ -209,7 +209,13 @@ func CreatePanel(c *gin.Context) {
 		return
 	}
 
-	messageData := data.IntoPanelMessageData(customId, premiumTier > premium.None)
+	footer, err := footerPolicyForGuild(c, guildId, botContext)
+	if err != nil {
+		_ = c.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to verify premium status"))
+		return
+	}
+
+	messageData := data.IntoPanelMessageData(customId, footer.ShowBranding)
 	msgId, err := messageData.send(botContext)
 	if err != nil {
 		var unwrapped request.RestError

--- a/backend/app/http/endpoints/api/panel/paneldelete.go
+++ b/backend/app/http/endpoints/api/panel/paneldelete.go
@@ -94,6 +94,12 @@ func DeletePanel(c *gin.Context) {
 		return
 	}
 
+	footer, err := footerPolicyForGuild(c, guildId, botContext)
+	if err != nil {
+		_ = c.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to delete panel"))
+		return
+	}
+
 	// Re-enforce the free tier panel limit after deletion.
 	if premiumTier == premium.None {
 		if err := database.Client.Panel.ForceDisableSome(c, guildId, freePanelLimit); err != nil {
@@ -115,7 +121,7 @@ func DeletePanel(c *gin.Context) {
 			return
 		}
 
-		messageData := multiPanelIntoMessageData(multiPanel, premiumTier > premium.None)
+		messageData := multiPanelIntoMessageData(multiPanel, footer)
 		messageId, err := messageData.send(botContext, panels)
 		if err != nil {
 			var unwrapped request.RestError

--- a/backend/app/http/endpoints/api/panel/panelmessagedata.go
+++ b/backend/app/http/endpoints/api/panel/panelmessagedata.go
@@ -24,10 +24,10 @@ type panelMessageData struct {
 	ButtonStyle              component.ButtonStyle
 	ButtonLabel              string
 	ButtonDisabled           bool
-	IsPremium                bool
+	ShowBranding             bool
 }
 
-func panelIntoMessageData(panel database.Panel, isPremium bool) panelMessageData {
+func panelIntoMessageData(panel database.Panel, showBranding bool) panelMessageData {
 	var emote *emoji.Emoji
 	if panel.EmojiName != nil { // No emoji = nil
 		if panel.EmojiId == nil { // Unicode emoji
@@ -54,7 +54,7 @@ func panelIntoMessageData(panel database.Panel, isPremium bool) panelMessageData
 		ButtonStyle:    component.ButtonStyle(panel.ButtonStyle),
 		ButtonLabel:    panel.ButtonLabel,
 		ButtonDisabled: panel.Disabled,
-		IsPremium:      isPremium,
+		ShowBranding:   showBranding,
 	}
 }
 
@@ -72,7 +72,7 @@ func (p *panelMessageData) send(c *botcontext.BotContext) (uint64, error) {
 		e.SetThumbnail(*p.ThumbnailUrl)
 	}
 
-	if !p.IsPremium {
+	if p.ShowBranding {
 		e.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 
@@ -115,7 +115,7 @@ func (p *panelMessageData) edit(c *botcontext.BotContext, messageId uint64) erro
 		e.SetThumbnail(*p.ThumbnailUrl)
 	}
 
-	if !p.IsPremium {
+	if p.ShowBranding {
 		e.SetFooter(fmt.Sprintf("Powered by %s", config.Conf.Bot.PoweredBy), config.Conf.Bot.IconUrl)
 	}
 

--- a/backend/app/http/endpoints/api/panel/panelresend.go
+++ b/backend/app/http/endpoints/api/panel/panelresend.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/TicketsBot-cloud/common/featureflags"
-	"github.com/TicketsBot-cloud/common/premium"
 	"github.com/TicketsBot-cloud/database"
 	"github.com/TicketsBot-cloud/gdl/rest"
 	"github.com/TicketsBot-cloud/gdl/rest/request"
@@ -15,7 +14,6 @@ import (
 	"github.com/ticketsbot-cloud/dashboard/backend/app/http/audit"
 	"github.com/ticketsbot-cloud/dashboard/backend/botcontext"
 	dbclient "github.com/ticketsbot-cloud/dashboard/backend/database"
-	"github.com/ticketsbot-cloud/dashboard/backend/rpc"
 	"github.com/ticketsbot-cloud/dashboard/backend/utils"
 )
 
@@ -73,13 +71,13 @@ func ResendPanel(ctx *gin.Context) {
 		}
 	}
 
-	premiumTier, err := rpc.PremiumClient.GetTierByGuildId(ctx, guildId, true, botContext.Token, botContext.RateLimiter)
+	footer, err := footerPolicyForGuild(ctx, guildId, botContext)
 	if err != nil {
 		ctx.JSON(500, utils.ErrorStr("Unable to verify premium status. Please try again."))
 		return
 	}
 
-	messageData := panelIntoMessageData(panel, premiumTier > premium.None)
+	messageData := panelIntoMessageData(panel, footer.ShowBranding)
 	msgId, err := messageData.send(botContext)
 	if err != nil {
 		var unwrapped request.RestError

--- a/backend/app/http/endpoints/api/panel/panelupdate.go
+++ b/backend/app/http/endpoints/api/panel/panelupdate.go
@@ -89,6 +89,12 @@ func UpdatePanel(c *gin.Context) {
 		return
 	}
 
+	footer, err := footerPolicyForGuild(c, guildId, botContext)
+	if err != nil {
+		_ = c.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to update panel"))
+		return
+	}
+
 	// TODO: Use proper context
 	channels, err := botContext.GetGuildChannels(context.Background(), guildId)
 	if err != nil {
@@ -160,7 +166,7 @@ func UpdatePanel(c *gin.Context) {
 		}
 	}
 
-	messageData := data.IntoPanelMessageData(existing.CustomId, premiumTier > premium.None)
+	messageData := data.IntoPanelMessageData(existing.CustomId, footer.ShowBranding)
 	var newMessageId uint64
 
 	// Check if channel changed
@@ -401,7 +407,7 @@ func UpdatePanel(c *gin.Context) {
 			return
 		}
 
-		messageData := multiPanelIntoMessageData(multiPanel, premiumTier > premium.None)
+		messageData := multiPanelIntoMessageData(multiPanel, footer)
 
 		// Try to edit message first
 		var messageId uint64

--- a/frontend/src/components/PanelPreview.tsx
+++ b/frontend/src/components/PanelPreview.tsx
@@ -3,6 +3,7 @@ import Button from "@/components/discord/container/Button";
 import SelectMenu from "@/components/discord/container/SelectMenu";
 import DiscordContent from "@/components/discord/DiscordContent";
 import type { Panel, MultiPanel, MultiPanelRequest } from "@/types";
+import { BRANDING_FOOTER_ICON, BRANDING_FOOTER_TEXT } from "@/lib/constants";
 import { formatEmbedTimestampForDisplay } from "@/lib/embed-timestamp";
 import { isSafeUrl } from "@/lib/url";
 import { previewAvatarUrl } from "@/lib/embed-avatar";
@@ -22,9 +23,10 @@ interface PanelPreviewProps {
     panel: Panel | MultiPanel | MultiPanelRequest | MultiPanelPreviewRequest;
     buttons?: Panel[];
   };
+  brandingFooter?: boolean;
 }
 
-const PanelPreview: FC<PanelPreviewProps> = ({ type, data }) => {
+const PanelPreview: FC<PanelPreviewProps> = ({ type, data, brandingFooter }) => {
   const { panel, buttons } = data;
 
   if (type === "panel") {
@@ -116,6 +118,10 @@ const PanelPreview: FC<PanelPreviewProps> = ({ type, data }) => {
   const footerIconUrl = resolveTicketAvatar(footerIconUrlRaw);
   const footerTimestamp = formatEmbedTimestampForDisplay(embedData?.timestamp);
 
+  // Timestamp survives branding, as it does bot-side.
+  const displayFooterText = brandingFooter ? BRANDING_FOOTER_TEXT : footerText;
+  const displayFooterIconUrl = brandingFooter ? BRANDING_FOOTER_ICON : footerIconUrl;
+
   const thumbnailUrl = resolveTicketAvatar(embedData?.thumbnail_url);
   const imageUrl = resolveTicketAvatar(embedData?.image_url);
   const authorIconUrl = resolveTicketAvatar(embedData?.author?.icon_url);
@@ -190,14 +196,14 @@ const PanelPreview: FC<PanelPreviewProps> = ({ type, data }) => {
             <img src={imageUrl} alt="Embedded" className="w-full h-auto rounded-sm" />
           </div>
         )}
-        {(footerText || footerTimestamp) && (
+        {(displayFooterText || footerTimestamp) && (
           <div className="mt-3 flex items-center gap-2">
-            {footerIconUrl && (
-              <img src={footerIconUrl} alt="Footer Icon" className="w-5 h-5 rounded-full" />
+            {displayFooterIconUrl && (
+              <img src={displayFooterIconUrl} alt="Footer Icon" className="w-5 h-5 rounded-full" />
             )}
             <p className="text-xs text-[#dbdee1]">
-              {footerText}
-              {footerText && footerTimestamp ? " • " : ""}
+              {displayFooterText}
+              {displayFooterText && footerTimestamp ? " • " : ""}
               {footerTimestamp}
             </p>
           </div>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -16,3 +16,6 @@ export const PATREON_URL = env.VITE_PATREON_URL || "https://www.patreon.com/tick
 export const WEBSITE_URL = env.VITE_WEBSITE_URL || "https://tickets.bot";
 export const KB_DOMAIN = env.VITE_KB_DOMAIN || "kb.tickets.bot";
 export const GROWTHBOOK_URL = env.VITE_GROWTHBOOK_URL || "http://growthbook.prod";
+export const POWERED_BY = env.VITE_POWERED_BY || "Tickets.bot";
+export const BRANDING_FOOTER_TEXT = `Powered by ${POWERED_BY}`;
+export const BRANDING_FOOTER_ICON = "https://tickets.bot/assets/img/logo.png";

--- a/frontend/src/pages/manage/multipanels/create.tsx
+++ b/frontend/src/pages/manage/multipanels/create.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type FC } from "react";
 import { apiClient, SKIP_ERROR_TOAST } from "@/lib/api";
-import { useGuildEmojis, useGuildPanels } from "@/hooks/queries/useGuild";
+import { useGuildEmojis, useGuildPanels, useGuildPremium } from "@/hooks/queries/useGuild";
 import { useParams, useNavigate } from "react-router";
 
 import { getGuildById } from "@/stores/auth";
@@ -18,8 +18,10 @@ import PanelPreview from "@/components/PanelPreview";
 import DateTimePicker from "@/components/DateTimePicker";
 import Button from "@/components/Button";
 import FeatureLockBanner from "@/components/FeatureLockBanner";
+import PremiumGate from "@/components/PremiumGate";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_PANELS } from "@/lib/feature-flags";
+import { BRANDING_FOOTER_TEXT } from "@/lib/constants";
 import { parseEmbedTimestamp, serializeEmbedTimestamp } from "@/lib/embed-timestamp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
@@ -169,6 +171,9 @@ const MultiPanelsPage: FC = () => {
   };
   const { data: panels = [] } = useGuildPanels(guildId);
   const { data: guildEmojis = [] } = useGuildEmojis(guildId, true);
+  const { data: premiumState = null } = useGuildPremium(guildId, false);
+  const { data: brandingPremium = null } = useGuildPremium(guildId, true);
+  const showBrandingFooter = !brandingPremium?.premium;
 
   return (
     <MainLayout
@@ -451,44 +456,51 @@ const MultiPanelsPage: FC = () => {
               />
             </Collapsible>
             <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-              <Textarea
-                label="Footer Text"
-                placeholder="e.g. Powered by TicketBot"
-                value={multiPanel.embed?.footer?.text || ""}
-                onChange={(e) =>
-                  setMultiPanel((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          embed: {
-                            ...prev.embed,
-                            footer: { ...prev.embed?.footer, text: e },
-                          },
-                        }
-                      : prev,
-                  )
-                }
-                max={EMBED_LIMITS.FOOTER_TEXT}
-              />
-              <TextInput
-                label="Footer Icon URL"
-                placeholder="e.g. https://example.com/footer-icon.png"
-                value={multiPanel.embed?.footer?.icon_url || ""}
-                onChange={(e) =>
-                  setMultiPanel((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          embed: {
-                            ...prev.embed,
-                            footer: { ...prev.embed?.footer, icon_url: e },
-                          },
-                        }
-                      : prev,
-                  )
-                }
-                maxLength={EMBED_LIMITS.URL}
-              />
+              <PremiumGate
+                isPremium={!!premiumState?.premium}
+                feature="custom-footer"
+                description={`Without premium this footer is replaced with “${BRANDING_FOOTER_TEXT}”.`}
+                variant="overlay"
+              >
+                <Textarea
+                  label="Footer Text"
+                  placeholder="e.g. Support hours: 9am-5pm UTC"
+                  value={multiPanel.embed?.footer?.text || ""}
+                  onChange={(e) =>
+                    setMultiPanel((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            embed: {
+                              ...prev.embed,
+                              footer: { ...prev.embed?.footer, text: e },
+                            },
+                          }
+                        : prev,
+                    )
+                  }
+                  max={EMBED_LIMITS.FOOTER_TEXT}
+                />
+                <TextInput
+                  label="Footer Icon URL"
+                  placeholder="e.g. https://example.com/footer-icon.png"
+                  value={multiPanel.embed?.footer?.icon_url || ""}
+                  onChange={(e) =>
+                    setMultiPanel((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            embed: {
+                              ...prev.embed,
+                              footer: { ...prev.embed?.footer, icon_url: e },
+                            },
+                          }
+                        : prev,
+                    )
+                  }
+                  maxLength={EMBED_LIMITS.URL}
+                />
+              </PremiumGate>
               <DateTimePicker
                 label="Footer Timestamp (Optional)"
                 value={parseEmbedTimestamp(multiPanel.embed?.timestamp)}
@@ -512,6 +524,7 @@ const MultiPanelsPage: FC = () => {
             <PanelPreview
               type="welcome"
               data={{ panel: multiPanel, buttons: getPreviewButtons() }}
+              brandingFooter={showBrandingFooter}
             />
           </div>
         </div>

--- a/frontend/src/pages/manage/multipanels/edit.tsx
+++ b/frontend/src/pages/manage/multipanels/edit.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type FC } from "react";
 import { apiClient, SKIP_ERROR_TOAST } from "@/lib/api";
-import { useGuildEmojis, useGuildPanels } from "@/hooks/queries/useGuild";
+import { useGuildEmojis, useGuildPanels, useGuildPremium } from "@/hooks/queries/useGuild";
 import { useParams, useNavigate } from "react-router";
 
 import { getGuildById } from "@/stores/auth";
@@ -18,8 +18,10 @@ import PanelPreview from "@/components/PanelPreview";
 import DateTimePicker from "@/components/DateTimePicker";
 import Button from "@/components/Button";
 import FeatureLockBanner from "@/components/FeatureLockBanner";
+import PremiumGate from "@/components/PremiumGate";
 import { useFeatureLock } from "@/hooks/useFeatureLock";
 import { FEATURE_PANELS } from "@/lib/feature-flags";
+import { BRANDING_FOOTER_TEXT } from "@/lib/constants";
 import { parseEmbedTimestamp, serializeEmbedTimestamp } from "@/lib/embed-timestamp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSave, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
@@ -90,6 +92,9 @@ const MultiPanelsPage: FC = () => {
   const [multiPanel, setMultiPanel] = useState<MultiPanel | null>(null);
   const { data: panels = [] } = useGuildPanels(guildId);
   const { data: guildEmojis = [] } = useGuildEmojis(guildId, true);
+  const { data: premiumState = null } = useGuildPremium(guildId, false);
+  const { data: brandingPremium = null } = useGuildPremium(guildId, true);
+  const showBrandingFooter = !brandingPremium?.premium;
 
   const getPanelById = (id: number) => panels.find((p) => p.panel_id === id);
 
@@ -437,44 +442,51 @@ const MultiPanelsPage: FC = () => {
               />
             </Collapsible>
             <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-              <Textarea
-                label="Footer Text"
-                placeholder="e.g. Powered by TicketBot"
-                value={multiPanel?.embed?.footer?.text || ""}
-                onChange={(e) =>
-                  setMultiPanel((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          embed: {
-                            ...prev.embed,
-                            footer: { ...prev.embed?.footer, text: e },
-                          },
-                        }
-                      : prev,
-                  )
-                }
-                max={EMBED_LIMITS.FOOTER_TEXT}
-              />
-              <TextInput
-                label="Footer Icon URL"
-                placeholder="e.g. https://example.com/footer-icon.png"
-                value={multiPanel?.embed?.footer?.icon_url || ""}
-                onChange={(e) =>
-                  setMultiPanel((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          embed: {
-                            ...prev.embed,
-                            footer: { ...prev.embed?.footer, icon_url: e },
-                          },
-                        }
-                      : prev,
-                  )
-                }
-                maxLength={EMBED_LIMITS.URL}
-              />
+              <PremiumGate
+                isPremium={!!premiumState?.premium}
+                feature="custom-footer"
+                description={`Without premium this footer is replaced with “${BRANDING_FOOTER_TEXT}”.`}
+                variant="overlay"
+              >
+                <Textarea
+                  label="Footer Text"
+                  placeholder="e.g. Support hours: 9am-5pm UTC"
+                  value={multiPanel?.embed?.footer?.text || ""}
+                  onChange={(e) =>
+                    setMultiPanel((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            embed: {
+                              ...prev.embed,
+                              footer: { ...prev.embed?.footer, text: e },
+                            },
+                          }
+                        : prev,
+                    )
+                  }
+                  max={EMBED_LIMITS.FOOTER_TEXT}
+                />
+                <TextInput
+                  label="Footer Icon URL"
+                  placeholder="e.g. https://example.com/footer-icon.png"
+                  value={multiPanel?.embed?.footer?.icon_url || ""}
+                  onChange={(e) =>
+                    setMultiPanel((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            embed: {
+                              ...prev.embed,
+                              footer: { ...prev.embed?.footer, icon_url: e },
+                            },
+                          }
+                        : prev,
+                    )
+                  }
+                  maxLength={EMBED_LIMITS.URL}
+                />
+              </PremiumGate>
               <DateTimePicker
                 label="Footer Timestamp (Optional)"
                 value={parseEmbedTimestamp(multiPanel?.embed?.timestamp)}
@@ -499,6 +511,7 @@ const MultiPanelsPage: FC = () => {
               <PanelPreview
                 type="welcome"
                 data={{ panel: multiPanel, buttons: getPreviewButtons() }}
+                brandingFooter={showBrandingFooter}
               />
             )}
           </div>

--- a/frontend/src/pages/manage/panels/create.tsx
+++ b/frontend/src/pages/manage/panels/create.tsx
@@ -35,6 +35,7 @@ import FeatureLockBanner from "@/components/FeatureLockBanner";
 import { parseEmbedTimestamp, serializeEmbedTimestamp } from "@/lib/embed-timestamp";
 import { panelEmoteName, preparePanelForApi } from "@/lib/panel-payload";
 import { FEATURE_PANELS } from "@/lib/feature-flags";
+import { BRANDING_FOOTER_TEXT } from "@/lib/constants";
 import ConfirmModal from "@/components/modals/ConfirmModal";
 import TicketModeInfoModal from "@/components/modals/TicketModeInfoModal";
 import PremiumGate from "@/components/PremiumGate";
@@ -72,6 +73,8 @@ const PanelsPage: FC = () => {
   const queryClient = useQueryClient();
   const { data: forms = [] } = useGuildForms(guildId);
   const { data: premiumState = null } = useGuildPremium(guildId, false);
+  const { data: brandingPremium = null } = useGuildPremium(guildId, true);
+  const showBrandingFooter = !brandingPremium?.premium;
   const { data: kbCategories = [] } = useKBCategories(guildId);
   const { data: guildEmojis = [] } = useGuildEmojis(guildId, true);
   const [isLoadingClone, setIsLoadingClone] = useState(!!clonePanelId);
@@ -150,9 +153,7 @@ const PanelsPage: FC = () => {
     welcome_message: {
       description: "Thank you for opening a ticket! A member of staff will be with you shortly.",
       colour: "#5865f2",
-      footer: {
-        text: "Powered by Tickets.bot.bot",
-      },
+      footer: {},
       author: {},
       fields: [],
     },
@@ -719,44 +720,51 @@ const PanelsPage: FC = () => {
               />
             </Collapsible>
             <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-              <Textarea
-                label="Footer Text"
-                placeholder="e.g. Powered by TicketBot"
-                value={panel.welcome_message?.footer?.text || ""}
-                onChange={(e) =>
-                  setPanel((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          welcome_message: {
-                            ...prev.welcome_message,
-                            footer: { ...prev.welcome_message?.footer, text: e },
-                          },
-                        }
-                      : prev,
-                  )
-                }
-                max={EMBED_LIMITS.FOOTER_TEXT}
-              />
-              <TextInput
-                label="Footer Icon URL"
-                placeholder="e.g. https://example.com/footer-icon.png"
-                value={panel.welcome_message?.footer?.icon_url || ""}
-                onChange={(e) =>
-                  setPanel((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          welcome_message: {
-                            ...prev.welcome_message,
-                            footer: { ...prev.welcome_message?.footer, icon_url: e },
-                          },
-                        }
-                      : prev,
-                  )
-                }
-                maxLength={EMBED_LIMITS.URL}
-              />
+              <PremiumGate
+                isPremium={!!premiumState?.premium}
+                feature="custom-footer"
+                description={`Without premium this footer is replaced with “${BRANDING_FOOTER_TEXT}”.`}
+                variant="overlay"
+              >
+                <Textarea
+                  label="Footer Text"
+                  placeholder="e.g. Support hours: 9am-5pm UTC"
+                  value={panel.welcome_message?.footer?.text || ""}
+                  onChange={(e) =>
+                    setPanel((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            welcome_message: {
+                              ...prev.welcome_message,
+                              footer: { ...prev.welcome_message?.footer, text: e },
+                            },
+                          }
+                        : prev,
+                    )
+                  }
+                  max={EMBED_LIMITS.FOOTER_TEXT}
+                />
+                <TextInput
+                  label="Footer Icon URL"
+                  placeholder="e.g. https://example.com/footer-icon.png"
+                  value={panel.welcome_message?.footer?.icon_url || ""}
+                  onChange={(e) =>
+                    setPanel((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            welcome_message: {
+                              ...prev.welcome_message,
+                              footer: { ...prev.welcome_message?.footer, icon_url: e },
+                            },
+                          }
+                        : prev,
+                    )
+                  }
+                  maxLength={EMBED_LIMITS.URL}
+                />
+              </PremiumGate>
               <DateTimePicker
                 label="Footer Timestamp (Optional)"
                 value={parseEmbedTimestamp(panel.welcome_message?.timestamp)}
@@ -790,7 +798,7 @@ const PanelsPage: FC = () => {
 
           <div>
             <span className="text-xl font-semibold">Welcome Message Preview</span>
-            <PanelPreview type="welcome" data={{ panel }} />
+            <PanelPreview type="welcome" data={{ panel }} brandingFooter={showBrandingFooter} />
           </div>
         </div>
       </Collapsible>

--- a/frontend/src/pages/manage/panels/edit.tsx
+++ b/frontend/src/pages/manage/panels/edit.tsx
@@ -36,6 +36,7 @@ import FeatureLockBanner from "@/components/FeatureLockBanner";
 import { parseEmbedTimestamp, serializeEmbedTimestamp } from "@/lib/embed-timestamp";
 import { panelEmoteName, preparePanelForApi } from "@/lib/panel-payload";
 import { FEATURE_PANELS } from "@/lib/feature-flags";
+import { BRANDING_FOOTER_TEXT } from "@/lib/constants";
 import PremiumGate from "@/components/PremiumGate";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSave, faTrash, faCrown } from "@fortawesome/free-solid-svg-icons";
@@ -69,6 +70,8 @@ const EditPanelsPage: FC = () => {
   const queryClient = useQueryClient();
   const { data: forms = [] } = useGuildForms(guildId);
   const { data: premiumState = null } = useGuildPremium(guildId, false);
+  const { data: brandingPremium = null } = useGuildPremium(guildId, true);
+  const showBrandingFooter = !brandingPremium?.premium;
   const { data: kbCategories = [] } = useKBCategories(guildId);
   const { data: guildEmojis = [] } = useGuildEmojis(guildId, true);
   const { data: panelData, isLoading: isLoadingPanel } = useGuildPanel(guildId, panelId);
@@ -639,44 +642,51 @@ const EditPanelsPage: FC = () => {
               />
             </Collapsible>
             <Collapsible title="" subtitle="Footer Settings" defaultOpen={false}>
-              <Textarea
-                label="Footer Text"
-                placeholder="e.g. Powered by TicketBot"
-                value={panel.welcome_message?.footer?.text || ""}
-                onChange={(e) =>
-                  setPanel((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          welcome_message: {
-                            ...prev.welcome_message,
-                            footer: { ...prev.welcome_message?.footer, text: e },
-                          },
-                        }
-                      : prev,
-                  )
-                }
-                max={EMBED_LIMITS.FOOTER_TEXT}
-              />
-              <TextInput
-                label="Footer Icon URL"
-                placeholder="e.g. https://example.com/footer-icon.png"
-                value={panel.welcome_message?.footer?.icon_url || ""}
-                onChange={(e) =>
-                  setPanel((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          welcome_message: {
-                            ...prev.welcome_message,
-                            footer: { ...prev.welcome_message?.footer, icon_url: e },
-                          },
-                        }
-                      : prev,
-                  )
-                }
-                maxLength={EMBED_LIMITS.URL}
-              />
+              <PremiumGate
+                isPremium={!!premiumState?.premium}
+                feature="custom-footer"
+                description={`Without premium this footer is replaced with “${BRANDING_FOOTER_TEXT}”.`}
+                variant="overlay"
+              >
+                <Textarea
+                  label="Footer Text"
+                  placeholder="e.g. Support hours: 9am-5pm UTC"
+                  value={panel.welcome_message?.footer?.text || ""}
+                  onChange={(e) =>
+                    setPanel((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            welcome_message: {
+                              ...prev.welcome_message,
+                              footer: { ...prev.welcome_message?.footer, text: e },
+                            },
+                          }
+                        : prev,
+                    )
+                  }
+                  max={EMBED_LIMITS.FOOTER_TEXT}
+                />
+                <TextInput
+                  label="Footer Icon URL"
+                  placeholder="e.g. https://example.com/footer-icon.png"
+                  value={panel.welcome_message?.footer?.icon_url || ""}
+                  onChange={(e) =>
+                    setPanel((prev) =>
+                      prev
+                        ? {
+                            ...prev,
+                            welcome_message: {
+                              ...prev.welcome_message,
+                              footer: { ...prev.welcome_message?.footer, icon_url: e },
+                            },
+                          }
+                        : prev,
+                    )
+                  }
+                  maxLength={EMBED_LIMITS.URL}
+                />
+              </PremiumGate>
               <DateTimePicker
                 label="Footer Timestamp (Optional)"
                 value={parseEmbedTimestamp(panel.welcome_message?.timestamp)}
@@ -710,7 +720,7 @@ const EditPanelsPage: FC = () => {
 
           <div>
             <span className="text-xl font-semibold">Welcome Message Preview</span>
-            <PanelPreview type="welcome" data={{ panel }} />
+            <PanelPreview type="welcome" data={{ panel }} brandingFooter={showBrandingFooter} />
           </div>
         </div>
       </Collapsible>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig(({ mode }) => {
     // First-party and Discord
     "https://tickets.bot",
     "https://cdn.tickets.bot",
+    "https://image-cdn.tickets.bot",
     "https://cdn.discordapp.com",
     "https://media.discordapp.net",
     "https://dbl-static.b-cdn.net",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,7 +25,8 @@ export default defineConfig(({ mode }) => {
   // so this keeps them from pointing a viewer's browser at an arbitrary host.
   const imgSrcHosts = [
     // First-party and Discord
-    "https://image-cdn.tickets.bot",
+    "https://tickets.bot",
+    "https://cdn.tickets.bot",
     "https://cdn.discordapp.com",
     "https://media.discordapp.net",
     "https://dbl-static.b-cdn.net",


### PR DESCRIPTION
## Description
Free servers can edit an embed footer today, but the bot overwrites it with our branding on the message it actually sends, so the setting silently does nothing.

Applies one rule across the panel welcome message and the multi-panel embed:

| Tier | Can edit footer | Rendered footer |
| --- | --- | --- |
| No premium | No | `Powered by Tickets.bot` |
| Voting premium | No | none |
| Premium / Whitelabel | Yes | their own |

Voting is detected via `model.EntitlementSourceVoting` — `GetTierByGuildId` is just `GetTierByGuildIdWithSource` with voting collapsed to `None`, so one lookup gives both.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Make a panel in a non-premium server → it should have the branded footer  
Make a panel in a vote-premium server → it should not have the branded footer  
Make a panel in a premium server → it should have a custom footer

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
