### PR TITLE
Fix: Re-creating admin commands wipes the admin server's tag command aliases

### DIFF
--- a/backend/app/http/endpoints/api/admin/utilities/recreatemain.go
+++ b/backend/app/http/endpoints/api/admin/utilities/recreatemain.go
@@ -2,14 +2,18 @@ package utilities
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"strings"
 
+	dbmodel "github.com/TicketsBot-cloud/database"
 	"github.com/TicketsBot-cloud/gdl/objects/interaction"
 	"github.com/TicketsBot-cloud/gdl/rest"
 	"github.com/TicketsBot-cloud/worker/bot/command/manager"
 	"github.com/gin-gonic/gin"
 	"github.com/ticketsbot-cloud/dashboard/backend/botcontext"
 	"github.com/ticketsbot-cloud/dashboard/backend/config"
+	"github.com/ticketsbot-cloud/dashboard/backend/database"
 	"github.com/ticketsbot-cloud/dashboard/backend/utils"
 )
 
@@ -52,11 +56,36 @@ func RecreateMainCommands() func(*gin.Context) {
 		adminSkipped := false
 		if adminGuildId != 0 {
 			_, adminCommands := cm.BuildCreatePayload(false, &adminGuildId)
-			if _, err := rest.ModifyGuildCommands(context.Background(), config.Conf.Bot.Token, botCtx.RateLimiter, config.Conf.Bot.Id, adminGuildId, adminCommands); err != nil {
+			adminCount = countLeafCommands(adminCommands)
+
+			// This is a replace-everything PUT, so the guild's tag aliases have to be part of the
+			// payload or they are deleted.
+			tags, err := database.Client.Tag.GetByGuild(c, adminGuildId)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, utils.ErrorStr("Failed to load the admin guild's tag command aliases"))
+				return
+			}
+
+			adminCommands = append(adminCommands, tagAliasCommands(tags)...)
+
+			existing, err := rest.GetGuildCommands(context.Background(), config.Conf.Bot.Token, botCtx.RateLimiter, config.Conf.Bot.Id, adminGuildId)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, utils.ErrorStr("Failed to read the main bot's existing admin slash commands"))
+				return
+			}
+
+			adminCommands = mergeExisting(existing, adminCommands)
+
+			registered, err := rest.ModifyGuildCommands(context.Background(), config.Conf.Bot.Token, botCtx.RateLimiter, config.Conf.Bot.Id, adminGuildId, adminCommands)
+			if err != nil {
 				c.JSON(http.StatusInternalServerError, utils.ErrorStr("Failed to re-create the main bot's admin slash commands"))
 				return
 			}
-			adminCount = countLeafCommands(adminCommands)
+
+			if err := reconcileTagAliasIds(c, adminGuildId, tags, registered); err != nil {
+				c.JSON(http.StatusInternalServerError, utils.ErrorStr("Admin slash commands were re-created, but the tag alias command IDs could not be updated"))
+				return
+			}
 		} else if !body.AdminOnly {
 			// Global-only run because no admin guild is configured — report it so the UI can say so.
 			adminSkipped = true
@@ -70,6 +99,79 @@ func RecreateMainCommands() func(*gin.Context) {
 			"admin_skipped": adminSkipped,
 		})
 	}
+}
+
+// Must match what CreateTag registers when an alias is first enabled.
+func tagAliasCommands(tags map[string]dbmodel.Tag) []rest.CreateCommandData {
+	commands := make([]rest.CreateCommandData, 0, len(tags))
+	for _, tag := range tags {
+		if tag.ApplicationCommandId == nil {
+			continue
+		}
+
+		commands = append(commands, rest.CreateCommandData{
+			Name:        tag.Id,
+			Description: fmt.Sprintf("Alias for /tag %s", tag.Id),
+			Options:     nil,
+			Type:        interaction.ApplicationCommandTypeChatInput,
+		})
+	}
+
+	return commands
+}
+
+// Carries over commands this endpoint did not build, which the overwrite would otherwise delete.
+func mergeExisting(existing []interaction.ApplicationCommand, target []rest.CreateCommandData) []rest.CreateCommandData {
+	for _, cmd := range existing {
+		var found bool
+		for _, newCmd := range target {
+			if cmd.Name == newCmd.Name {
+				found = true
+				break
+			}
+		}
+
+		if found {
+			continue
+		}
+
+		// ApplicationCommand.Type is tagged "application_command_type", which Discord never sends,
+		// so it always decodes as 0 and cannot be carried over.
+		target = append(target, rest.CreateCommandData{
+			Id:          cmd.Id,
+			Name:        cmd.Name,
+			Description: cmd.Description,
+			Options:     cmd.Options,
+			Type:        interaction.ApplicationCommandTypeChatInput,
+			Contexts:    cmd.Contexts,
+		})
+	}
+
+	return target
+}
+
+// CreateCommandData.Id is not serialised as a string, so a command carried through the overwrite is
+// not guaranteed to keep its snowflake, and the worker resolves aliases by ID.
+func reconcileTagAliasIds(
+	ctx context.Context,
+	guildId uint64,
+	tags map[string]dbmodel.Tag,
+	registered []interaction.ApplicationCommand,
+) error {
+	query := `UPDATE tags SET "application_command_id" = $1 WHERE "guild_id" = $2 AND LOWER("tag_id") = LOWER($3);`
+
+	for _, cmd := range registered {
+		tag, ok := tags[strings.ToLower(cmd.Name)]
+		if !ok || tag.ApplicationCommandId == nil || *tag.ApplicationCommandId == cmd.Id {
+			continue
+		}
+
+		if _, err := database.Client.Tag.Exec(ctx, query, cmd.Id, guildId, tag.Id); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // countLeafCommands counts the invocable "leaf" commands across the given command set. Commands


### PR DESCRIPTION
## Description
Custom tag command aliases in the admin server disappear whenever the owner utilities "Re-create main commands" / "Only re-create admin commands" action is used. Restoring them required each affected server to toggle every alias off and back on in the dashboard.

Only the admin server is affected, because it is the only guild where we register commands at guild level.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Custom tags should show again when creating the admin commands

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
