### PR TITLE
Fix: Masked links with angle-bracketed URLs render as literal text

### DIFF
--- a/backend/email/markdown.go
+++ b/backend/email/markdown.go
@@ -415,8 +415,7 @@ var (
 	reChannelMention = regexp.MustCompile(`^<#(\d+)>`)
 	reAngleLink      = regexp.MustCompile(`^<(https?://[^\s<>]+)>`)
 	reGlobalMention  = regexp.MustCompile(`^@(everyone|here)\b`)
-	// The url group balances one paren level so `…/Foo_(bar)` survives.
-	reMaskedLink = regexp.MustCompile(`^\[((?:[^\][]|\[[^\]]*\])+)\]\(((?:[^()\s]|\([^()\s]*\))+)\)`)
+	reMaskedLink = regexp.MustCompile(`^\[((?:[^\][]|\[[^\]]*\])+)\]\((?:<(https?://[^\s<>]+)>|((?:[^()\s]|\([^()\s]*\))+))\)`)
 	// The final class excludes trailing punctuation, so `(https://example.com/x.)`
 	// keeps the `.)`.
 	reBareLink = regexp.MustCompile(`^https?://[^\s<]*[^<.,:;"')\]\s]`)
@@ -495,7 +494,11 @@ func matchMaskedLink(src string, at int) (mdNode, int, bool) {
 	if m == nil {
 		return mdNode{}, 0, false
 	}
-	return buildLink(m[2], m[0], &m[1]), at + len(m[0]), true
+	rawURL := m[2]
+	if rawURL == "" {
+		rawURL = m[3]
+	}
+	return buildLink(rawURL, m[0], &m[1]), at + len(m[0]), true
 }
 
 func matchBareLink(src string, at int) (mdNode, int, bool) {

--- a/frontend/src/lib/discord-markdown.ts
+++ b/frontend/src/lib/discord-markdown.ts
@@ -125,8 +125,8 @@ const INLINE_RULES: Record<string, InlineRule[]> = {
   // The url group balances one paren level so `…/Foo_(bar)` survives.
   "[": [
     {
-      re: /\[((?:[^\][]|\[[^\]]*\])+)\]\(((?:[^()\s]|\([^()\s]*\))+)\)/y,
-      build: (m) => buildLink(m[2], m[0], m[1]),
+      re: /\[((?:[^\][]|\[[^\]]*\])+)\]\((?:<(https?:\/\/[^\s<>]+)>|((?:[^()\s]|\([^()\s]*\))+))\)/y,
+      build: (m) => buildLink(m[2] ?? m[3], m[0], m[1]),
     },
   ],
 


### PR DESCRIPTION
## Description
Discord accepts two URL forms in a masked link — `[text](https://example.com)` and `[text](<https://example.com>)`, where the angle brackets only suppress the URL embed underneath. Both render as a hyperlink in Discord; the dashboard only handled the first, so `[test](<https://example.com>)` in a tag embed description showed up as literal text in the preview.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
In any embed that use markdown, use hyperlink format [Text](<Link>)

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
