### PR TITLE
Rename panel switch claim behavior labels

### DIFF
--- a/frontend/src/components/modals/PanelSwitchBehaviourInfoModal.tsx
+++ b/frontend/src/components/modals/PanelSwitchBehaviourInfoModal.tsx
@@ -23,7 +23,7 @@ const PanelSwitchBehaviourInfoModal: FC<PanelSwitchBehaviourInfoModalProps> = ({
     >
       <div className="p-6 pr-12">
         <h2 id={titleId} className="text-xl font-semibold text-white mb-3">
-          Panel Switch Behaviour
+          Claim Behaviour on Panel Switch
         </h2>
         <p className="text-gray-300 text-sm mb-6 leading-relaxed">
           When a staff member moves a claimed ticket to another panel, these options control what

--- a/frontend/src/pages/manage/GuildSettings.tsx
+++ b/frontend/src/pages/manage/GuildSettings.tsx
@@ -30,12 +30,12 @@ const PanelSwitchSelect: FC<{ value: number; onChange: (v: number) => void }> = 
   return (
     <div className="flex flex-col">
       <div className="mb-1 flex items-center gap-1.5">
-        <span className="text-white">Panel Switch Behaviour</span>
+        <span className="text-white">Claim Behaviour on Panel Switch</span>
         <Button
           variant="ghost"
           size="icon"
           className="text-gray-400 hover:text-gray-200"
-          aria-label="Learn more about Panel Switch Behaviour"
+          aria-label="Learn more about Claim Behaviour on Panel Switch"
           onClick={() => setInfoOpen(true)}
         >
           <FontAwesomeIcon icon={faInfoCircle} className="w-4 h-4" aria-hidden="true" />


### PR DESCRIPTION
## Description
Updates the guild settings label and info modal title from “Panel Switch Behaviour” to “Claim Behaviour on Panel Switch,” and aligns the info button aria-label with the new wording for consistency and clarity.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Correction?

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
