### PR TITLE
Fix: Apply the default team automatically when creating a panel

### DIFF
--- a/frontend/src/pages/manage/panels/create.tsx
+++ b/frontend/src/pages/manage/panels/create.tsx
@@ -115,6 +115,8 @@ const PanelsPage: FC = () => {
     emoji_name: "📩",
     mentions: [],
     kb_category_ids: [],
+    teams: [],
+    default_team: true,
     mention_behaviour: "none",
     use_custom_emoji: false,
     disabled: false,


### PR DESCRIPTION
## Description
The **Support Teams** picker on `/manage/:guildId/panels/create` starts empty. Nothing forces a choice — `validateTeams` returns early on an empty array and `default_team` is unvalidated — so a panel saved without opening the Routing section is stored with `default_team = false` and no `panel_teams` rows.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Try to create a newww panel

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
