### PR TITLE
Fix: Awaiting Response Category cannot be unset

### DIFF
--- a/backend/app/http/endpoints/api/panel/panelcreate.go
+++ b/backend/app/http/endpoints/api/panel/panelcreate.go
@@ -124,13 +124,13 @@ func CreatePanel(c *gin.Context) {
 	data.MessageId = 0
 
 	// Check panel quota
-	premiumTier, err := rpc.PremiumClient.GetTierByGuildId(c, guildId, false, botContext.Token, botContext.RateLimiter)
+	quotaTier, err := rpc.PremiumClient.GetTierByGuildId(c, guildId, false, botContext.Token, botContext.RateLimiter)
 	if err != nil {
 		_ = c.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to verify premium status"))
 		return
 	}
 
-	if premiumTier == premium.None {
+	if quotaTier == premium.None {
 		panels, err := dbclient.Client.Panel.GetByGuild(c, guildId)
 		if err != nil {
 			_ = c.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to fetch existing panels"))
@@ -165,11 +165,21 @@ func CreatePanel(c *gin.Context) {
 		data.OverflowCategoryId = nil
 	}
 
+	// Voting premium unlocks fields but not quota, so the tier is looked up twice.
+	featureTier := quotaTier
+	if featureTier == premium.None {
+		featureTier, err = rpc.PremiumClient.GetTierByGuildId(c, guildId, true, botContext.Token, botContext.RateLimiter)
+		if err != nil {
+			_ = c.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to verify premium status"))
+			return
+		}
+	}
+
 	// Do custom validation
 	validationContext := PanelValidationContext{
 		Data:       data,
 		GuildId:    guildId,
-		IsPremium:  premiumTier > premium.None,
+		IsPremium:  featureTier > premium.None,
 		BotContext: botContext,
 		Channels:   channels,
 		Roles:      roles,

--- a/frontend/src/pages/manage/panels/create.tsx
+++ b/frontend/src/pages/manage/panels/create.tsx
@@ -73,8 +73,8 @@ const PanelsPage: FC = () => {
   const queryClient = useQueryClient();
   const { data: forms = [] } = useGuildForms(guildId);
   const { data: premiumState = null } = useGuildPremium(guildId, false);
-  const { data: brandingPremium = null } = useGuildPremium(guildId, true);
-  const showBrandingFooter = !brandingPremium?.premium;
+  const { data: premiumWithVoting = null } = useGuildPremium(guildId, true);
+  const showBrandingFooter = !premiumWithVoting?.premium;
   const { data: kbCategories = [] } = useKBCategories(guildId);
   const { data: guildEmojis = [] } = useGuildEmojis(guildId, true);
   const [isLoadingClone, setIsLoadingClone] = useState(!!clonePanelId);
@@ -464,26 +464,33 @@ const PanelsPage: FC = () => {
             }
           />
 
-          <Select
-            label={
-              premiumState?.premium
-                ? "Awaiting Response Category"
-                : "Awaiting Response Category (Premium)"
-            }
-            disabled={!premiumState?.premium}
-            options={
-              selectedGuild?.channels
-                ?.filter((c) => c.type == 4)
-                .map((channel) => ({
-                  label: channel.name,
-                  key: channel.id,
-                })) || []
-            }
-            value={panel.pending_category || ""}
-            onChange={(e) =>
-              setPanel((prev) => (prev ? { ...prev, pending_category: e ?? undefined } : prev))
-            }
-          />
+          <div>
+            <div className="flex items-center gap-1.5 mb-1">
+              <span className="text-sm text-white">Awaiting Response Category</span>
+              {!premiumWithVoting?.premium && (
+                <span title="Move tickets to a separate category while they await a user reply. Requires Premium.">
+                  <FontAwesomeIcon icon={faCrown} className="text-amber-400 text-xs cursor-help" />
+                </span>
+              )}
+            </div>
+            <Select
+              label="Awaiting Response Category"
+              hideLabel
+              showNoneOption={true}
+              noneOptionLabel="No Awaiting Response Category"
+              options={
+                selectedGuild?.channels
+                  ?.filter((c) => c.type == 4)
+                  .map((channel) => ({
+                    label: channel.name,
+                    key: channel.id,
+                    disabled: !premiumWithVoting?.premium,
+                  })) || []
+              }
+              value={panel.pending_category ?? null}
+              onChange={(e) => setPanel((prev) => (prev ? { ...prev, pending_category: e } : prev))}
+            />
+          </div>
         </div>
         <div className="p-4 grid gap-4 grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
           <Select

--- a/frontend/src/pages/manage/panels/edit.tsx
+++ b/frontend/src/pages/manage/panels/edit.tsx
@@ -70,8 +70,8 @@ const EditPanelsPage: FC = () => {
   const queryClient = useQueryClient();
   const { data: forms = [] } = useGuildForms(guildId);
   const { data: premiumState = null } = useGuildPremium(guildId, false);
-  const { data: brandingPremium = null } = useGuildPremium(guildId, true);
-  const showBrandingFooter = !brandingPremium?.premium;
+  const { data: premiumWithVoting = null } = useGuildPremium(guildId, true);
+  const showBrandingFooter = !premiumWithVoting?.premium;
   const { data: kbCategories = [] } = useKBCategories(guildId);
   const { data: guildEmojis = [] } = useGuildEmojis(guildId, true);
   const { data: panelData, isLoading: isLoadingPanel } = useGuildPanel(guildId, panelId);
@@ -383,26 +383,33 @@ const EditPanelsPage: FC = () => {
             }
           />
 
-          <Select
-            label={
-              premiumState?.premium
-                ? "Awaiting Response Category"
-                : "Awaiting Response Category (Premium)"
-            }
-            disabled={!premiumState?.premium}
-            options={
-              selectedGuild?.channels
-                ?.filter((c) => c.type == 4)
-                .map((channel) => ({
-                  label: channel.name,
-                  key: channel.id,
-                })) || []
-            }
-            value={panel.pending_category || ""}
-            onChange={(e) =>
-              setPanel((prev) => (prev ? { ...prev, pending_category: e ?? undefined } : prev))
-            }
-          />
+          <div>
+            <div className="flex items-center gap-1.5 mb-1">
+              <span className="text-sm text-white">Awaiting Response Category</span>
+              {!premiumWithVoting?.premium && (
+                <span title="Move tickets to a separate category while they await a user reply. Requires Premium.">
+                  <FontAwesomeIcon icon={faCrown} className="text-amber-400 text-xs cursor-help" />
+                </span>
+              )}
+            </div>
+            <Select
+              label="Awaiting Response Category"
+              hideLabel
+              showNoneOption={true}
+              noneOptionLabel="No Awaiting Response Category"
+              options={
+                selectedGuild?.channels
+                  ?.filter((c) => c.type == 4)
+                  .map((channel) => ({
+                    label: channel.name,
+                    key: channel.id,
+                    disabled: !premiumWithVoting?.premium,
+                  })) || []
+              }
+              value={panel.pending_category ?? null}
+              onChange={(e) => setPanel((prev) => (prev ? { ...prev, pending_category: e } : prev))}
+            />
+          </div>
         </div>
         <div className="p-4 grid gap-4 grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
           <Select

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -193,7 +193,7 @@ export interface Panel {
   has_support_hours?: boolean;
   is_currently_active?: boolean;
   exit_survey_form_id?: number | null;
-  pending_category?: string;
+  pending_category?: string | null;
   mention_behaviour: string;
   transcript_channel_id?: string;
   use_threads: boolean;


### PR DESCRIPTION
## Description
Once a panel's Awaiting Response Category was set, there was no way to unset it — the dropdown had no "None" entry, so the only escape was deleting the Discord category.

The backend already supported unset (`pending_category` is nullable, and `validatePendingCategory` returns nil early when the value is nil), so this was a UI gap.

It also caused a save lock-out: `validation.go:277` rejects a non-nil value for non-premium guilds, but the dropdown was `disabled` for those guilds. A server whose premium lapsed with a category set could not save **any** edit to that panel, with no way to clear the offending field.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Set Awaiting Response Category to the none value

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
