### PR TITLE
Fix onboarding permission checks and stale state

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -628,11 +628,13 @@ export const apiClient = {
   },
 
   onboarding: {
-    get: (guildId: string) => api.get<OnboardingState>(`/api/${guildId}/onboarding`),
+    get: (guildId: string) =>
+      api.get<OnboardingState>(`/api/${guildId}/onboarding`, SKIP_ERROR_TOAST),
     update: (
       guildId: string,
       body: { current_step?: number; completed?: boolean; skipped?: boolean },
-    ) => api.post<{ success: boolean }>(`/api/${guildId}/onboarding`, body),
+      config?: AxiosRequestConfig,
+    ) => api.post<{ success: boolean }>(`/api/${guildId}/onboarding`, body, config),
     getFeaturedListings: (guildId: string) =>
       api.get<GalleryListing[]>(`/api/${guildId}/gallery/featured`),
   },

--- a/frontend/src/pages/manage/GuildLayout.tsx
+++ b/frontend/src/pages/manage/GuildLayout.tsx
@@ -16,7 +16,7 @@ export default function GuildLayout() {
   const navigate = useNavigate();
   const { selectedGuild, selectGuild, updateGuild } = useGuildStore();
   const updateGuildPermission = useAuthStore((s) => s.updateGuildPermission);
-  const { setState: setOnboardingState } = useOnboardingStore();
+  const { setState: setOnboardingState, reset: resetOnboarding } = useOnboardingStore();
   const [verified, setVerified] = useState(false);
   const [bootstrapReady, setBootstrapReady] = useState(false);
 
@@ -32,6 +32,7 @@ export default function GuildLayout() {
 
     setVerified(false);
     setBootstrapReady(false);
+    resetOnboarding();
 
     let cancelled = false;
 
@@ -155,6 +156,7 @@ export default function GuildLayout() {
     updateGuildPermission,
     navigate,
     setOnboardingState,
+    resetOnboarding,
     isTranscriptView,
   ]);
 
@@ -177,7 +179,7 @@ export default function GuildLayout() {
   return (
     <GuildBootstrapContext.Provider value={true}>
       <GuildContext.Provider value={selectedGuild == undefined ? null : selectedGuild}>
-        {guildId && (selectedGuild?.permission_level ?? 0) >= 1 && (
+        {guildId && (selectedGuild?.permission_level ?? 0) >= 2 && (
           <OnboardingBanner guildId={guildId} />
         )}
         <Outlet />

--- a/frontend/src/pages/manage/setup/SetupLayout.tsx
+++ b/frontend/src/pages/manage/setup/SetupLayout.tsx
@@ -67,6 +67,13 @@ function SetupLayoutContent() {
       return;
     }
 
+    if ((g.permission_level ?? 0) < 2) {
+      selectGuild(null);
+      toast.warning("You need administrator permissions to access the setup wizard.");
+      navigate("/", { replace: true });
+      return;
+    }
+
     setVerified(false);
 
     const verifyAndLoad = async () => {

--- a/frontend/src/pages/manage/setup/components/OnboardingBanner.tsx
+++ b/frontend/src/pages/manage/setup/components/OnboardingBanner.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { Link } from "react-router";
-import { apiClient } from "@/lib/api";
+import { apiClient, SKIP_ERROR_TOAST } from "@/lib/api";
 import { useOnboardingStore } from "@/stores/onboarding";
 import Button from "@/components/Button";
 import { useFeatureFlag } from "@/hooks/useFeatureFlag";
@@ -17,13 +17,20 @@ const OnboardingBanner: FC<OnboardingBannerProps> = ({ guildId }) => {
     guildId,
   );
 
-  if (!state || state.onboarding_completed || state.skipped || flagLoading || !wizardEnabled) {
+  if (
+    !state ||
+    state.guild_id !== guildId ||
+    state.onboarding_completed ||
+    state.skipped ||
+    flagLoading ||
+    !wizardEnabled
+  ) {
     return null;
   }
 
   const handleDismiss = async () => {
     try {
-      await apiClient.onboarding.update(guildId, { skipped: true });
+      await apiClient.onboarding.update(guildId, { skipped: true }, SKIP_ERROR_TOAST);
       setOnboardingState({ ...state, skipped: true });
     } catch {
       // Silently fail - the banner will persist until next page load


### PR DESCRIPTION
## Description
GuildLayout: reset onboarding store on guild change, and only show the banner for admins (permission_level >= 2). SetupLayout: pre-check cached permission and redirect non-admins. OnboardingBanner: ignore stale store entries by checking state.guild_id and use SKIP_ERROR_TOAST when dismissing the banner.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
