### PR TITLE
Validate embed URLs across imports and UI

### DIFF
--- a/backend/app/http/endpoints/api/gallery/galleryimport.go
+++ b/backend/app/http/endpoints/api/gallery/galleryimport.go
@@ -92,6 +92,19 @@ func ImportHandler(ctx *gin.Context) {
 		return
 	}
 
+	var welcomeMessage *database.CustomEmbed
+	if len(listing.WelcomeMessage) > 0 {
+		var parsed database.CustomEmbed
+		if err := stdjson.Unmarshal(listing.WelcomeMessage, &parsed); err == nil {
+			welcomeMessage = &parsed
+		}
+	}
+
+	if err := validateListingUrls(welcomeMessage, listing.ImageUrl, listing.ThumbnailUrl); err != nil {
+		ctx.JSON(http.StatusBadRequest, utils.ErrorStr("%s", err.Error()))
+		return
+	}
+
 	// Generate a unique custom ID for the new panel
 	customId, err := utils.RandString(30)
 	if err != nil {
@@ -139,18 +152,15 @@ func ImportHandler(ctx *gin.Context) {
 		HideClaimButton:           false,
 	}
 
-	// Store the welcome message embed if one exists in the listing
-	if len(listing.WelcomeMessage) > 0 {
-		var customEmbed database.CustomEmbed
-		if err := stdjson.Unmarshal(listing.WelcomeMessage, &customEmbed); err == nil {
-			customEmbed.GuildId = guildId
-			embedId, err := dbclient.Client.Embeds.CreateWithFields(ctx, &customEmbed, nil)
-			if err != nil {
-				_ = ctx.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to save welcome message embed"))
-				return
-			}
-			panel.WelcomeMessageEmbed = &embedId
+	if welcomeMessage != nil {
+		welcomeMessage.GuildId = guildId
+		embedId, err := dbclient.Client.Embeds.CreateWithFields(ctx, welcomeMessage, nil)
+		if err != nil {
+			_ = ctx.AbortWithError(http.StatusInternalServerError, app.NewError(err, "Failed to save welcome message embed"))
+			return
 		}
+
+		panel.WelcomeMessageEmbed = &embedId
 	}
 
 	// If a channel ID is provided, send the panel message to Discord

--- a/backend/app/http/endpoints/api/gallery/import_tag.go
+++ b/backend/app/http/endpoints/api/gallery/import_tag.go
@@ -97,6 +97,13 @@ func ImportTagHandler(ctx *gin.Context) {
 		return
 	}
 
+	if snapshot.Embed != nil {
+		if err := validateListingUrls(snapshot.Embed.CustomEmbed); err != nil {
+			ctx.JSON(http.StatusBadRequest, utils.ErrorStr("%s", err.Error()))
+			return
+		}
+	}
+
 	// Build the tag struct from the snapshot
 	tag := database.Tag{
 		Id:      body.TagId,

--- a/backend/app/http/endpoints/api/gallery/importvalidation.go
+++ b/backend/app/http/endpoints/api/gallery/importvalidation.go
@@ -1,0 +1,29 @@
+package gallery
+
+import (
+	"errors"
+
+	"github.com/TicketsBot-cloud/database"
+	"github.com/ticketsbot-cloud/dashboard/backend/utils/types"
+)
+
+// Snapshots may predate URL validation, and the importer cannot edit someone else's listing.
+func validateListingUrls(e *database.CustomEmbed, panelUrls ...*string) error {
+	for _, url := range panelUrls {
+		if url == nil || *url == "" || types.IsValidEmbedUrl(*url) {
+			continue
+		}
+
+		return errors.New("This listing contains an image URL that is not a valid http:// or https:// URL, so it cannot be imported")
+	}
+
+	if e == nil {
+		return nil
+	}
+
+	if err := types.NewCustomEmbed(e, nil).ValidateUrls(); err != nil {
+		return errors.New("This listing cannot be imported: " + err.Error())
+	}
+
+	return nil
+}

--- a/backend/app/http/endpoints/api/kb/articles.go
+++ b/backend/app/http/endpoints/api/kb/articles.go
@@ -468,6 +468,10 @@ func cleanAndValidateEmbed(embed *types.CustomEmbed) error {
 		return fmt.Errorf("your embed contained the following errors:\n%s", utils.FormatValidationErrors(validationErrors))
 	}
 
+	if err := embed.ValidateUrls(); err != nil {
+		return err
+	}
+
 	if total := embed.TotalCharacterCount(); total > types.EmbedTotalCharacterLimit {
 		return fmt.Errorf("total embed characters (%d) exceeds Discord's %d character limit", total, types.EmbedTotalCharacterLimit)
 	}

--- a/backend/app/http/endpoints/api/panel/validation.go
+++ b/backend/app/http/endpoints/api/panel/validation.go
@@ -451,6 +451,11 @@ func validateEmbed(e *types.CustomEmbed) error {
 		return validation.NewInvalidInputError("Your embed message does not contain any content")
 	}
 
+	if err := e.ValidateUrls(); err != nil {
+		return validation.NewInvalidInputError(err.Error())
+	}
+
+	// urlRegex additionally constrains host shape here; ValidateUrls is scheme-only.
 	for _, url := range []*string{e.ImageUrl, e.ThumbnailUrl} {
 		if url == nil || *url == types.AvatarUrlPlaceholder {
 			continue

--- a/backend/app/http/endpoints/api/tags/tagcreate.go
+++ b/backend/app/http/endpoints/api/tags/tagcreate.go
@@ -98,8 +98,12 @@ func CreateTag(ctx *gin.Context) {
 		return
 	}
 
-	// Validate total embed character count
 	if data.Embed != nil {
+		if err := data.Embed.ValidateUrls(); err != nil {
+			ctx.JSON(400, utils.ErrorStr("%s", err.Error()))
+			return
+		}
+
 		totalChars := data.Embed.TotalCharacterCount()
 		if totalChars > types.EmbedTotalCharacterLimit {
 			formatted := fmt.Sprintf("Total embed characters (%d) exceeds Discord's %d character limit", totalChars, types.EmbedTotalCharacterLimit)

--- a/backend/utils/netutils.go
+++ b/backend/utils/netutils.go
@@ -63,6 +63,20 @@ func ValidateWebhookUrl(rawUrl string) error {
 	return nil
 }
 
+// Not url.Parse: it rejects invalid percent-escapes, failing URLs already stored today.
+func ValidateHttpUrl(rawUrl string) error {
+	lower := strings.ToLower(rawUrl)
+	if !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
+		return errors.New("URL must start with http:// or https://")
+	}
+
+	if strings.TrimSpace(urlAuthority(rawUrl)) == "" {
+		return errors.New("URL must include a host")
+	}
+
+	return nil
+}
+
 func urlAuthority(rawUrl string) string {
 	_, after, found := strings.Cut(rawUrl, "://")
 	if !found {

--- a/backend/utils/types/customembed.go
+++ b/backend/utils/types/customembed.go
@@ -1,6 +1,9 @@
 package types
 
 import (
+	"fmt"
+	"sort"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/TicketsBot-cloud/database"
@@ -48,6 +51,44 @@ type Field struct {
 	Name   string `json:"name" validate:"min=1,max=256"`
 	Value  string `json:"value" validate:"min=1,max=1024"`
 	Inline bool   `json:"inline"`
+}
+
+func IsValidEmbedUrl(rawUrl string) bool {
+	return rawUrl == AvatarUrlPlaceholder || utils.ValidateHttpUrl(rawUrl) == nil
+}
+
+// Keys are the dashboard's field labels, so a rejection names the box the user sees.
+func (c *CustomEmbed) urlFields() map[string]*string {
+	if c == nil {
+		return nil
+	}
+
+	return map[string]*string{
+		"Title URL":       c.Url,
+		"Author Icon URL": c.Author.IconUrl,
+		"Author URL":      c.Author.Url,
+		"Thumbnail URL":   c.ThumbnailUrl,
+		"Image URL":       c.ImageUrl,
+		"Footer Icon URL": c.Footer.IconUrl,
+	}
+}
+
+func (c *CustomEmbed) ValidateUrls() error {
+	var invalid []string
+	for label, value := range c.urlFields() {
+		if value == nil || *value == "" || IsValidEmbedUrl(*value) {
+			continue
+		}
+
+		invalid = append(invalid, label)
+	}
+
+	if len(invalid) == 0 {
+		return nil
+	}
+
+	sort.Strings(invalid) // map iteration order is random; the message must be stable
+	return fmt.Errorf("the following must be valid http:// or https:// URLs: %s", strings.Join(invalid, ", "))
 }
 
 func NewCustomEmbed(c *database.CustomEmbed, fields []database.EmbedField) *CustomEmbed {

--- a/frontend/src/components/modals/TagEditorModal.tsx
+++ b/frontend/src/components/modals/TagEditorModal.tsx
@@ -13,6 +13,7 @@ import DiscordContent from "@/components/discord/DiscordContent";
 import DateTimePicker from "@/components/DateTimePicker";
 import { useKBArticles } from "@/hooks/queries/useKB";
 import { parseEmbedTimestamp, serializeEmbedTimestamp } from "@/lib/embed-timestamp";
+import { embedUrlError } from "@/lib/embed-url";
 import type { Tag, TagEmbed } from "@/types";
 import { EMBED_LIMITS } from "@/constants/embedLimits";
 import { BRANDING_FOOTER_TEXT } from "@/lib/constants";
@@ -297,6 +298,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                       label="Title URL"
                       placeholder="e.g. https://example.com"
                       value={embed.url || ""}
+                      error={embedUrlError(embed.url)}
                       onChange={(v) => setEmbed((prev) => ({ ...prev, url: v }))}
                       maxLength={EMBED_LIMITS.URL}
                     />
@@ -327,6 +329,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                           label="Author Icon URL"
                           placeholder="https://example.com/icon.png"
                           value={embed.author?.icon_url || ""}
+                          error={embedUrlError(embed.author?.icon_url)}
                           onChange={(v) =>
                             setEmbed((prev) => ({
                               ...prev,
@@ -339,6 +342,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                           label="Author URL"
                           placeholder="https://example.com"
                           value={embed.author?.url || ""}
+                          error={embedUrlError(embed.author?.url)}
                           onChange={(v) =>
                             setEmbed((prev) => ({
                               ...prev,
@@ -355,6 +359,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                         label="Thumbnail URL"
                         placeholder="https://example.com/thumbnail.png"
                         value={embed.thumbnail_url || ""}
+                        error={embedUrlError(embed.thumbnail_url)}
                         onChange={(v) => setEmbed((prev) => ({ ...prev, thumbnail_url: v }))}
                         maxLength={EMBED_LIMITS.URL}
                       />
@@ -362,6 +367,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                         label="Image URL"
                         placeholder="https://example.com/image.png"
                         value={embed.image_url || ""}
+                        error={embedUrlError(embed.image_url)}
                         onChange={(v) => setEmbed((prev) => ({ ...prev, image_url: v }))}
                         maxLength={EMBED_LIMITS.URL}
                       />
@@ -384,6 +390,7 @@ const TagEditorModal: FC<TagEditorModalProps> = ({
                         label="Footer Icon URL"
                         placeholder="https://example.com/footer-icon.png"
                         value={embed.footer?.icon_url || ""}
+                        error={embedUrlError(embed.footer?.icon_url)}
                         onChange={(v) =>
                           setEmbed((prev) => ({
                             ...prev,

--- a/frontend/src/lib/embed-avatar.ts
+++ b/frontend/src/lib/embed-avatar.ts
@@ -1,6 +1,6 @@
 import { defaultAvatarUrl } from "@/lib/discord-cdn";
 
-const AVATAR_PLACEHOLDER = "%avatar_url%";
+export const AVATAR_PLACEHOLDER = "%avatar_url%";
 
 export function previewAvatarUrl(url: string | null | undefined): string | null | undefined {
   return url === AVATAR_PLACEHOLDER ? defaultAvatarUrl() : url;

--- a/frontend/src/lib/embed-url.ts
+++ b/frontend/src/lib/embed-url.ts
@@ -1,0 +1,48 @@
+import { AVATAR_PLACEHOLDER } from "@/lib/embed-avatar";
+
+export interface EmbedUrlFields {
+  url?: string | null;
+  image_url?: string | null;
+  thumbnail_url?: string | null;
+  author?: { icon_url?: string | null; url?: string | null } | null;
+  footer?: { icon_url?: string | null } | null;
+}
+
+function urlAuthority(rawUrl: string): string {
+  const separator = rawUrl.indexOf("://");
+  if (separator === -1) return rawUrl;
+
+  const after = rawUrl.slice(separator + 3);
+  const end = after.search(/[/?#]/);
+  return end === -1 ? after : after.slice(0, end);
+}
+
+// Mirrors utils.ValidateHttpUrl. Not `new URL()`: it normalises "https:/example.com", which
+// the backend rejects, so the two sides would disagree about what is saveable.
+export function embedUrlError(value: string | null | undefined): string | undefined {
+  if (!value || value === AVATAR_PLACEHOLDER) return undefined;
+
+  const lower = value.toLowerCase();
+  if (!lower.startsWith("http://") && !lower.startsWith("https://")) {
+    return "URL must start with http:// or https://";
+  }
+
+  if (urlAuthority(value).trim() === "") return "URL must include a host";
+
+  return undefined;
+}
+
+export function collectEmbedUrlErrors(embed: EmbedUrlFields | null | undefined): string[] {
+  if (!embed) return [];
+
+  const fields: Array<[string, string | null | undefined]> = [
+    ["Title URL", embed.url],
+    ["Author Icon URL", embed.author?.icon_url],
+    ["Author URL", embed.author?.url],
+    ["Thumbnail URL", embed.thumbnail_url],
+    ["Image URL", embed.image_url],
+    ["Footer Icon URL", embed.footer?.icon_url],
+  ];
+
+  return fields.filter(([, value]) => embedUrlError(value) !== undefined).map(([label]) => label);
+}

--- a/frontend/src/pages/manage/kb/create.tsx
+++ b/frontend/src/pages/manage/kb/create.tsx
@@ -22,6 +22,7 @@ import { useKBCategories, useCreateKBArticle } from "@/hooks/queries/useKB";
 import type { TagEmbed } from "@/types";
 import { EMBED_LIMITS } from "@/constants/embedLimits";
 import { BRANDING_FOOTER_TEXT } from "@/lib/constants";
+import { embedUrlError } from "@/lib/embed-url";
 import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
 
 const defaultEmbed: TagEmbed = {
@@ -275,6 +276,7 @@ const CreateKBArticlePage: FC = () => {
                   label="Title URL"
                   placeholder="e.g. https://example.com"
                   value={embed.url || ""}
+                  error={embedUrlError(embed.url)}
                   onChange={(v) => setEmbed((prev) => ({ ...prev, url: v }))}
                   maxLength={EMBED_LIMITS.URL}
                 />
@@ -305,6 +307,7 @@ const CreateKBArticlePage: FC = () => {
                       label="Author Icon URL"
                       placeholder="https://example.com/icon.png"
                       value={embed.author?.icon_url || ""}
+                      error={embedUrlError(embed.author?.icon_url)}
                       onChange={(v) =>
                         setEmbed((prev) => ({
                           ...prev,
@@ -317,6 +320,7 @@ const CreateKBArticlePage: FC = () => {
                       label="Author URL"
                       placeholder="https://example.com"
                       value={embed.author?.url || ""}
+                      error={embedUrlError(embed.author?.url)}
                       onChange={(v) =>
                         setEmbed((prev) => ({
                           ...prev,
@@ -333,6 +337,7 @@ const CreateKBArticlePage: FC = () => {
                     label="Thumbnail URL"
                     placeholder="https://example.com/thumbnail.png"
                     value={embed.thumbnail_url || ""}
+                    error={embedUrlError(embed.thumbnail_url)}
                     onChange={(v) => setEmbed((prev) => ({ ...prev, thumbnail_url: v }))}
                     maxLength={EMBED_LIMITS.URL}
                   />
@@ -340,6 +345,7 @@ const CreateKBArticlePage: FC = () => {
                     label="Image URL"
                     placeholder="https://example.com/image.png"
                     value={embed.image_url || ""}
+                    error={embedUrlError(embed.image_url)}
                     onChange={(v) => setEmbed((prev) => ({ ...prev, image_url: v }))}
                     maxLength={EMBED_LIMITS.URL}
                   />
@@ -362,6 +368,7 @@ const CreateKBArticlePage: FC = () => {
                     label="Footer Icon URL"
                     placeholder="https://example.com/footer-icon.png"
                     value={embed.footer?.icon_url || ""}
+                    error={embedUrlError(embed.footer?.icon_url)}
                     onChange={(v) =>
                       setEmbed((prev) => ({
                         ...prev,

--- a/frontend/src/pages/manage/kb/edit.tsx
+++ b/frontend/src/pages/manage/kb/edit.tsx
@@ -23,6 +23,7 @@ import { useKBArticle, useKBCategories, useUpdateKBArticle } from "@/hooks/queri
 import type { TagEmbed } from "@/types";
 import { EMBED_LIMITS } from "@/constants/embedLimits";
 import { BRANDING_FOOTER_TEXT } from "@/lib/constants";
+import { embedUrlError } from "@/lib/embed-url";
 import EmbedCharacterTotal from "@/components/EmbedCharacterTotal";
 
 const defaultEmbed: TagEmbed = {
@@ -344,6 +345,7 @@ const EditKBArticlePage: FC = () => {
                   label="Title URL"
                   placeholder="e.g. https://example.com"
                   value={embed.url || ""}
+                  error={embedUrlError(embed.url)}
                   onChange={(v) => setEmbed((prev) => ({ ...prev, url: v }))}
                   maxLength={EMBED_LIMITS.URL}
                 />
@@ -374,6 +376,7 @@ const EditKBArticlePage: FC = () => {
                       label="Author Icon URL"
                       placeholder="https://example.com/icon.png"
                       value={embed.author?.icon_url || ""}
+                      error={embedUrlError(embed.author?.icon_url)}
                       onChange={(v) =>
                         setEmbed((prev) => ({
                           ...prev,
@@ -386,6 +389,7 @@ const EditKBArticlePage: FC = () => {
                       label="Author URL"
                       placeholder="https://example.com"
                       value={embed.author?.url || ""}
+                      error={embedUrlError(embed.author?.url)}
                       onChange={(v) =>
                         setEmbed((prev) => ({
                           ...prev,
@@ -402,6 +406,7 @@ const EditKBArticlePage: FC = () => {
                     label="Thumbnail URL"
                     placeholder="https://example.com/thumbnail.png"
                     value={embed.thumbnail_url || ""}
+                    error={embedUrlError(embed.thumbnail_url)}
                     onChange={(v) => setEmbed((prev) => ({ ...prev, thumbnail_url: v }))}
                     maxLength={EMBED_LIMITS.URL}
                   />
@@ -409,6 +414,7 @@ const EditKBArticlePage: FC = () => {
                     label="Image URL"
                     placeholder="https://example.com/image.png"
                     value={embed.image_url || ""}
+                    error={embedUrlError(embed.image_url)}
                     onChange={(v) => setEmbed((prev) => ({ ...prev, image_url: v }))}
                     maxLength={EMBED_LIMITS.URL}
                   />
@@ -431,6 +437,7 @@ const EditKBArticlePage: FC = () => {
                     label="Footer Icon URL"
                     placeholder="https://example.com/footer-icon.png"
                     value={embed.footer?.icon_url || ""}
+                    error={embedUrlError(embed.footer?.icon_url)}
                     onChange={(v) =>
                       setEmbed((prev) => ({
                         ...prev,

--- a/frontend/src/pages/manage/multipanels/create.tsx
+++ b/frontend/src/pages/manage/multipanels/create.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type FC } from "react";
 import { apiClient, SKIP_ERROR_TOAST } from "@/lib/api";
+import { collectEmbedUrlErrors, embedUrlError } from "@/lib/embed-url";
 import { useGuildEmojis, useGuildPanels, useGuildPremium } from "@/hooks/queries/useGuild";
 import { useParams, useNavigate } from "react-router";
 
@@ -172,6 +173,12 @@ const MultiPanelsPage: FC = () => {
     if (multiPanel.panels.length > 15) return "Multi-panels cannot contain more than 15 panels.";
     if (labellessPanelCount > 0) return "Every dropdown panel needs a label.";
     if (embedEmpty) return "The embed cannot be empty.";
+
+    const invalidUrls = collectEmbedUrlErrors(multiPanel?.embed);
+    if (invalidUrls.length > 0) {
+      return `Fix these embed URLs before saving: ${invalidUrls.join(", ")}.`;
+    }
+
     return null;
   };
 
@@ -384,6 +391,7 @@ const MultiPanelsPage: FC = () => {
                 label="Title URL"
                 placeholder="e.g. https://example.com"
                 value={multiPanel.embed?.url || ""}
+                error={embedUrlError(multiPanel.embed?.url)}
                 onChange={(e) =>
                   setMultiPanel((prev) =>
                     prev ? { ...prev, embed: { ...prev.embed, url: e } } : prev,
@@ -431,6 +439,7 @@ const MultiPanelsPage: FC = () => {
                   label="Author Icon URL"
                   placeholder="e.g. https://example.com/icon.png"
                   value={multiPanel.embed?.author?.icon_url || ""}
+                  error={embedUrlError(multiPanel.embed?.author?.icon_url)}
                   onChange={(e) =>
                     setMultiPanel((prev) =>
                       prev
@@ -450,6 +459,7 @@ const MultiPanelsPage: FC = () => {
                   label="Author URL"
                   placeholder="e.g. https://example.com"
                   value={multiPanel.embed?.author?.url || ""}
+                  error={embedUrlError(multiPanel.embed?.author?.url)}
                   onChange={(e) =>
                     setMultiPanel((prev) =>
                       prev
@@ -472,6 +482,7 @@ const MultiPanelsPage: FC = () => {
                 label="Thumbnail URL"
                 placeholder="e.g. https://example.com/thumbnail.png"
                 value={multiPanel.embed?.thumbnail_url || ""}
+                error={embedUrlError(multiPanel.embed?.thumbnail_url)}
                 onChange={(e) =>
                   setMultiPanel((prev) =>
                     prev
@@ -488,6 +499,7 @@ const MultiPanelsPage: FC = () => {
                 label="Image URL"
                 placeholder="e.g. https://example.com/image.png"
                 value={multiPanel.embed?.image_url || ""}
+                error={embedUrlError(multiPanel.embed?.image_url)}
                 onChange={(e) =>
                   setMultiPanel((prev) =>
                     prev ? { ...prev, embed: { ...prev.embed, image_url: e } } : prev,
@@ -526,6 +538,7 @@ const MultiPanelsPage: FC = () => {
                   label="Footer Icon URL"
                   placeholder="e.g. https://example.com/footer-icon.png"
                   value={multiPanel.embed?.footer?.icon_url || ""}
+                  error={embedUrlError(multiPanel.embed?.footer?.icon_url)}
                   onChange={(e) =>
                     setMultiPanel((prev) =>
                       prev

--- a/frontend/src/pages/manage/multipanels/edit.tsx
+++ b/frontend/src/pages/manage/multipanels/edit.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type FC } from "react";
 import { apiClient, SKIP_ERROR_TOAST } from "@/lib/api";
+import { collectEmbedUrlErrors, embedUrlError } from "@/lib/embed-url";
 import { useGuildEmojis, useGuildPanels, useGuildPremium } from "@/hooks/queries/useGuild";
 import { useParams, useNavigate } from "react-router";
 
@@ -179,6 +180,12 @@ const MultiPanelsPage: FC = () => {
     if (multiPanel.panels.length > 15) return "Multi-panels cannot contain more than 15 panels.";
     if (labellessPanelCount > 0) return "Every dropdown panel needs a label.";
     if (embedEmpty) return "The embed cannot be empty.";
+
+    const invalidUrls = collectEmbedUrlErrors(multiPanel?.embed);
+    if (invalidUrls.length > 0) {
+      return `Fix these embed URLs before saving: ${invalidUrls.join(", ")}.`;
+    }
+
     return null;
   };
 
@@ -385,6 +392,7 @@ const MultiPanelsPage: FC = () => {
                 label="Title URL"
                 placeholder="e.g. https://example.com"
                 value={multiPanel?.embed?.url || ""}
+                error={embedUrlError(multiPanel?.embed?.url)}
                 onChange={(e) =>
                   setMultiPanel((prev) =>
                     prev ? { ...prev, embed: { ...prev.embed, url: e } } : prev,
@@ -432,6 +440,7 @@ const MultiPanelsPage: FC = () => {
                   label="Author Icon URL"
                   placeholder="e.g. https://example.com/icon.png"
                   value={multiPanel?.embed?.author?.icon_url || ""}
+                  error={embedUrlError(multiPanel?.embed?.author?.icon_url)}
                   onChange={(e) =>
                     setMultiPanel((prev) =>
                       prev
@@ -451,6 +460,7 @@ const MultiPanelsPage: FC = () => {
                   label="Author URL"
                   placeholder="e.g. https://example.com"
                   value={multiPanel?.embed?.author?.url || ""}
+                  error={embedUrlError(multiPanel?.embed?.author?.url)}
                   onChange={(e) =>
                     setMultiPanel((prev) =>
                       prev
@@ -473,6 +483,7 @@ const MultiPanelsPage: FC = () => {
                 label="Thumbnail URL"
                 placeholder="e.g. https://example.com/thumbnail.png"
                 value={multiPanel?.embed?.thumbnail_url || ""}
+                error={embedUrlError(multiPanel?.embed?.thumbnail_url)}
                 onChange={(e) =>
                   setMultiPanel((prev) =>
                     prev
@@ -489,6 +500,7 @@ const MultiPanelsPage: FC = () => {
                 label="Image URL"
                 placeholder="e.g. https://example.com/image.png"
                 value={multiPanel?.embed?.image_url || ""}
+                error={embedUrlError(multiPanel?.embed?.image_url)}
                 onChange={(e) =>
                   setMultiPanel((prev) =>
                     prev ? { ...prev, embed: { ...prev.embed, image_url: e } } : prev,
@@ -527,6 +539,7 @@ const MultiPanelsPage: FC = () => {
                   label="Footer Icon URL"
                   placeholder="e.g. https://example.com/footer-icon.png"
                   value={multiPanel?.embed?.footer?.icon_url || ""}
+                  error={embedUrlError(multiPanel?.embed?.footer?.icon_url)}
                   onChange={(e) =>
                     setMultiPanel((prev) =>
                       prev

--- a/frontend/src/pages/manage/panels/create.tsx
+++ b/frontend/src/pages/manage/panels/create.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type FC } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { apiClient, SKIP_ERROR_TOAST } from "@/lib/api";
+import { collectEmbedUrlErrors, embedUrlError } from "@/lib/embed-url";
 import {
   guildKeys,
   useGuildEmojis,
@@ -273,6 +274,7 @@ const PanelsPage: FC = () => {
     !welcomeMessage.image_url?.trim() &&
     !welcomeMessage.thumbnail_url?.trim();
   const stale = (id?: string) => channelsLoaded && !!id && !existingChannelIds.has(id);
+  const invalidWelcomeMessageUrls = collectEmbedUrlErrors(panel.welcome_message);
   const hasMissingRequired =
     missingChannel ||
     missingCategory ||
@@ -282,7 +284,8 @@ const PanelsPage: FC = () => {
     stale(panel.category_id) ||
     stale(panel.transcript_channel_id) ||
     stale(panel.ticket_notification_channel) ||
-    welcomeMessageEmpty;
+    welcomeMessageEmpty ||
+    invalidWelcomeMessageUrls.length > 0;
 
   return (
     <MainLayout
@@ -666,6 +669,7 @@ const PanelsPage: FC = () => {
                 label="Title URL"
                 placeholder="e.g. https://example.com"
                 value={panel.welcome_message?.url || ""}
+                error={embedUrlError(panel.welcome_message?.url)}
                 onChange={(e) =>
                   setPanel((prev) =>
                     prev ? { ...prev, welcome_message: { ...prev.welcome_message, url: e } } : prev,
@@ -715,6 +719,7 @@ const PanelsPage: FC = () => {
                   label="Author Icon URL"
                   placeholder="e.g. https://example.com/icon.png"
                   value={panel.welcome_message?.author?.icon_url || ""}
+                  error={embedUrlError(panel.welcome_message?.author?.icon_url)}
                   onChange={(e) =>
                     setPanel((prev) =>
                       prev
@@ -734,6 +739,7 @@ const PanelsPage: FC = () => {
                   label="Author URL"
                   placeholder="e.g. https://example.com"
                   value={panel.welcome_message?.author?.url || ""}
+                  error={embedUrlError(panel.welcome_message?.author?.url)}
                   onChange={(e) =>
                     setPanel((prev) =>
                       prev
@@ -756,6 +762,7 @@ const PanelsPage: FC = () => {
                 label="Thumbnail URL"
                 placeholder="e.g. https://example.com/thumbnail.png"
                 value={panel.welcome_message?.thumbnail_url || ""}
+                error={embedUrlError(panel.welcome_message?.thumbnail_url)}
                 onChange={(e) =>
                   setPanel((prev) =>
                     prev
@@ -772,6 +779,7 @@ const PanelsPage: FC = () => {
                 label="Image URL"
                 placeholder="e.g. https://example.com/image.png"
                 value={panel.welcome_message?.image_url || ""}
+                error={embedUrlError(panel.welcome_message?.image_url)}
                 onChange={(e) =>
                   setPanel((prev) =>
                     prev
@@ -812,6 +820,7 @@ const PanelsPage: FC = () => {
                   label="Footer Icon URL"
                   placeholder="e.g. https://example.com/footer-icon.png"
                   value={panel.welcome_message?.footer?.icon_url || ""}
+                  error={embedUrlError(panel.welcome_message?.footer?.icon_url)}
                   onChange={(e) =>
                     setPanel((prev) =>
                       prev

--- a/frontend/src/pages/manage/panels/edit.tsx
+++ b/frontend/src/pages/manage/panels/edit.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type FC } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { apiClient, SKIP_ERROR_TOAST } from "@/lib/api";
+import { collectEmbedUrlErrors, embedUrlError } from "@/lib/embed-url";
 import {
   guildKeys,
   useGuildEmojis,
@@ -197,6 +198,7 @@ const EditPanelsPage: FC = () => {
     !welcomeMessage.image_url?.trim() &&
     !welcomeMessage.thumbnail_url?.trim();
   const stale = (id?: string) => channelsLoaded && !!id && !existingChannelIds.has(id);
+  const invalidWelcomeMessageUrls = collectEmbedUrlErrors(panel.welcome_message);
   const hasMissingRequired =
     missingChannel ||
     missingCategory ||
@@ -206,7 +208,8 @@ const EditPanelsPage: FC = () => {
     stale(panel.category_id) ||
     stale(panel.transcript_channel_id) ||
     stale(panel.ticket_notification_channel) ||
-    welcomeMessageEmpty;
+    welcomeMessageEmpty ||
+    invalidWelcomeMessageUrls.length > 0;
 
   return (
     <MainLayout
@@ -580,6 +583,7 @@ const EditPanelsPage: FC = () => {
                 label="Title URL"
                 placeholder="e.g. https://example.com"
                 value={panel.welcome_message?.url || ""}
+                error={embedUrlError(panel.welcome_message?.url)}
                 onChange={(e) =>
                   setPanel((prev) =>
                     prev ? { ...prev, welcome_message: { ...prev.welcome_message, url: e } } : prev,
@@ -629,6 +633,7 @@ const EditPanelsPage: FC = () => {
                   label="Author Icon URL"
                   placeholder="e.g. https://example.com/icon.png"
                   value={panel.welcome_message?.author?.icon_url || ""}
+                  error={embedUrlError(panel.welcome_message?.author?.icon_url)}
                   onChange={(e) =>
                     setPanel((prev) =>
                       prev
@@ -648,6 +653,7 @@ const EditPanelsPage: FC = () => {
                   label="Author URL"
                   placeholder="e.g. https://example.com"
                   value={panel.welcome_message?.author?.url || ""}
+                  error={embedUrlError(panel.welcome_message?.author?.url)}
                   onChange={(e) =>
                     setPanel((prev) =>
                       prev
@@ -670,6 +676,7 @@ const EditPanelsPage: FC = () => {
                 label="Thumbnail URL"
                 placeholder="e.g. https://example.com/thumbnail.png"
                 value={panel.welcome_message?.thumbnail_url || ""}
+                error={embedUrlError(panel.welcome_message?.thumbnail_url)}
                 onChange={(e) =>
                   setPanel((prev) =>
                     prev
@@ -686,6 +693,7 @@ const EditPanelsPage: FC = () => {
                 label="Image URL"
                 placeholder="e.g. https://example.com/image.png"
                 value={panel.welcome_message?.image_url || ""}
+                error={embedUrlError(panel.welcome_message?.image_url)}
                 onChange={(e) =>
                   setPanel((prev) =>
                     prev
@@ -726,6 +734,7 @@ const EditPanelsPage: FC = () => {
                   label="Footer Icon URL"
                   placeholder="e.g. https://example.com/footer-icon.png"
                   value={panel.welcome_message?.footer?.icon_url || ""}
+                  error={embedUrlError(panel.welcome_message?.footer?.icon_url)}
                   onChange={(e) =>
                     setPanel((prev) =>
                       prev


### PR DESCRIPTION
## Description
Adds consistent HTTP(S) URL validation for embed fields across backend and frontend. The backend now validates embed/panel/tag/KB URLs (including gallery imports and legacy listings) with stable, field-specific errors, while the frontend surfaces inline URL errors and blocks saves when embed URLs are invalid. Also exports the avatar placeholder and adds shared embed URL helpers to keep client/server behavior aligned.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement

## Testing
Try to add a none http/https url in any of the url embed fields

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
