### PR TITLE
Store multipanel embed color as hex string

### DIFF
--- a/frontend/src/components/PanelPreview.tsx
+++ b/frontend/src/components/PanelPreview.tsx
@@ -103,11 +103,7 @@ const PanelPreview: FC<PanelPreviewProps> = ({ type, data, brandingFooter }) => 
   const resolveTicketAvatar = (url: string | null | undefined) =>
     isMultiPanelRequest ? url : previewAvatarUrl(url);
 
-  const borderColor = isMultiPanelRequest
-    ? `#${((panel as MultiPanelRequest).embed.colour || 0x5865f2).toString(16).padStart(6, "0")}`
-    : typeof embedData?.colour === "number"
-      ? `#${embedData.colour.toString(16).padStart(6, "0")}`
-      : embedData?.colour || "#5865f2";
+  const borderColor = embedData?.colour || "#5865f2";
 
   const footerText = embedData?.footer
     ? typeof embedData.footer === "string"

--- a/frontend/src/pages/manage/multipanels/create.tsx
+++ b/frontend/src/pages/manage/multipanels/create.tsx
@@ -96,7 +96,7 @@ const MultiPanelsPage: FC = () => {
   const [multiPanel, setMultiPanel] = useState<MultiPanelDraft>({
     embed: {
       author: {},
-      colour: 0x5865f2,
+      colour: "#5865f2",
       description: "",
       fields: [],
       footer: {},
@@ -359,22 +359,10 @@ const MultiPanelsPage: FC = () => {
               />
               <ColourSelect
                 label="Colour"
-                value={
-                  multiPanel.embed?.colour
-                    ? `#${multiPanel.embed.colour.toString(16).padStart(6, "0")}`
-                    : "#5865f2"
-                }
+                value={multiPanel.embed?.colour || "#5865f2"}
                 onChange={(e) =>
                   setMultiPanel((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          embed: {
-                            ...prev.embed,
-                            colour: parseInt(e.replace("#", ""), 16),
-                          },
-                        }
-                      : prev,
+                    prev ? { ...prev, embed: { ...prev.embed, colour: e } } : prev,
                   )
                 }
               />

--- a/frontend/src/pages/manage/multipanels/edit.tsx
+++ b/frontend/src/pages/manage/multipanels/edit.tsx
@@ -40,7 +40,7 @@ import { useApiErrorHandler } from "@/hooks/useApiErrorHandler";
 
 const defaultEmbed = {
   author: {},
-  colour: 0x5865f2,
+  colour: "#5865f2",
   fields: [],
   footer: {},
 };
@@ -360,22 +360,10 @@ const MultiPanelsPage: FC = () => {
               />
               <ColourSelect
                 label="Colour"
-                value={
-                  multiPanel?.embed?.colour
-                    ? `#${multiPanel.embed.colour.toString(16).padStart(6, "0")}`
-                    : "#5865f2"
-                }
+                value={multiPanel?.embed?.colour || "#5865f2"}
                 onChange={(e) =>
                   setMultiPanel((prev) =>
-                    prev
-                      ? {
-                          ...prev,
-                          embed: {
-                            ...prev.embed,
-                            colour: parseInt(e.replace("#", ""), 16),
-                          },
-                        }
-                      : prev,
+                    prev ? { ...prev, embed: { ...prev.embed, colour: e } } : prev,
                   )
                 }
               />

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -284,7 +284,7 @@ export interface MultiPanelEmbed {
     icon_url?: string;
     url?: string;
   };
-  colour: number;
+  colour: string;
   description?: string;
   fields?: Array<{
     name: string;


### PR DESCRIPTION
## Description
Switch multipanel embed `colour` from numeric values to `#RRGGBB` strings across create/edit flows and type definitions. This removes repeated int/hex conversions in color inputs and updates preview rendering to use the embed color directly with a safe default.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Edit a multipanel, and change the panel embed colour field

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
